### PR TITLE
fix: notional truncation

### DIFF
--- a/tests/order.rs
+++ b/tests/order.rs
@@ -1799,7 +1799,6 @@ mod market {
         }
 
         #[tokio::test]
-        #[ignore = "currently different than python -- should be 178571428"]
         async fn should_succeed_0_01() -> anyhow::Result<()> {
             let server = MockServer::start();
             let client = create_authenticated(&server).await?;
@@ -1849,7 +1848,6 @@ mod market {
         }
 
         #[tokio::test]
-        #[ignore = "currently different than python -- should be 1785714285"]
         async fn should_succeed_0_001() -> anyhow::Result<()> {
             let server = MockServer::start();
             let client = create_authenticated(&server).await?;


### PR DESCRIPTION
We have to ensure that any calculated notional amounts are "snapped" to the combine precision of the tick size (number of decimals allowed for a price) and the lot size (number of decimals allowed for the number of shares)