### PR TITLE
fix: mask salt to 53 bits

### DIFF
--- a/src/order_builder.rs
+++ b/src/order_builder.rs
@@ -461,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn order_salt_should_be_less_than_2_to_the_53_minus_1() {
+    fn order_salt_should_be_less_than_or_equal_to_2_to_the_53_minus_1() {
         let raw_salt = u64::MAX;
         let masked_salt = to_ieee_754_int(raw_salt);
 


### PR DESCRIPTION
The backend will fail with "invalid order parameters" if the salt is greater than 2^53, as the backend is likely parsing it as a number.

If you want to try to repro this, set your salt to u64::MAX and place an order.