### PR TITLE
feat: add optional tracing instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,6 +3340,7 @@ dependencies = [
  "sha2",
  "strum_macros",
  "tokio",
+ "tracing",
  "url",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rust-version = "1.88.0" # MSRV
 [features]
 default = []
 gamma = []
+tracing = ["dep:tracing"]
 
 [dependencies]
 alloy = { version = "1.1.3", default-features = false, features = [
@@ -49,6 +50,7 @@ serde_json = "1.0.146"
 serde_with = { version = "3.16.1", features = ["chrono_0_4"] }
 sha2 = "0.10.9"
 strum_macros = "0.27.2"
+tracing = { version = "0.1", optional = true }
 url = "2.5.7"
 uuid = { version = "1.19.0", features = ["serde", "v4", "v7"] }
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This crate provides strongly typed request builders, authenticated endpoints, `a
 
 - [Overview](#overview)
 - [Getting Started](#getting-started)
+- [Features](#features)
 - [Examples](#examples)
 - [Setting Token Allowances](#token-allowances)
 - [Minimum Supported Rust Version (MSRV)](#minimum-supported-rust-version-msrv)
@@ -55,6 +56,21 @@ Then run any of the examples
 ```bash
 cargo run --example unauthenticated
 ```
+
+## Features
+
+### Tracing
+
+This crate supports optional structured logging via the [`tracing`](https://docs.rs/tracing) crate. When enabled, it provides detailed instrumentation for HTTP requests, authentication flows, caching, and order building.
+
+To enable tracing:
+
+```toml
+[dependencies]
+polymarket-client-sdk = { version = "0.1", features = ["tracing"] }
+```
+
+When the `tracing` feature is disabled (the default), all logging code is compiled out with zero runtime overhead.
 
 ## Examples
 

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -110,6 +110,10 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
     }
 
     /// Validates and transforms this limit builder into a [`SignableOrder`]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(self), err(level = "warn"))
+    )]
     pub async fn build(self) -> Result<SignableOrder> {
         let Some(token_id) = self.token_id.clone() else {
             return Err(Error::validation(
@@ -230,6 +234,9 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
             signatureType: self.signature_type as u8,
         };
 
+        #[cfg(feature = "tracing")]
+        tracing::debug!(token_id = %token_id, side = ?side, price = %price, size = %size, "limit order built");
+
         Ok(SignableOrder { order, order_type })
     }
 }
@@ -312,6 +319,10 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
     }
 
     /// Validates and transforms this limit builder into a [`SignableOrder`]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(self), err(level = "warn"))
+    )]
     pub async fn build(self) -> Result<SignableOrder> {
         let Some(token_id) = self.token_id.clone() else {
             return Err(Error::validation(
@@ -421,6 +432,9 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
             expiration: U256::ZERO,
             signatureType: self.signature_type as u8,
         };
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(token_id = %token_id, side = ?side, price = %price, amount = %amount.as_inner(), "market order built");
 
         Ok(SignableOrder { order, order_type })
     }


### PR DESCRIPTION
Add structured logging via the `tracing` crate behind an optional feature flag. When enabled, provides debug-level spans for HTTP requests with method, path, and status code fields, plus trace-level logging for cache operations and order building.

Closes #21