### PR TITLE
feat(auth): add secret and passphrase accessors to Credentials

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,7 +4,7 @@ use base64::engine::general_purpose::URL_SAFE;
 use hmac::{Hmac, Mac as _};
 use reqwest::header::HeaderMap;
 use reqwest::{Body, Request};
-use secrecy::{ExposeSecret as _, SecretString};
+pub use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use sha2::Sha256;
 use uuid::Uuid;
@@ -39,6 +39,18 @@ impl Credentials {
     #[must_use]
     pub fn key(&self) -> ApiKey {
         self.key
+    }
+
+    /// Returns the secret.
+    #[must_use]
+    pub fn secret(&self) -> &SecretString {
+        &self.secret
+    }
+
+    /// Returns the passphrase.
+    #[must_use]
+    pub fn passphrase(&self) -> &SecretString {
+        &self.passphrase
     }
 }
 

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -6,7 +6,7 @@ use alloy::signers::Signer as _;
 use alloy::signers::local::LocalSigner;
 use httpmock::MockServer;
 use polymarket_client_sdk::POLYGON;
-use polymarket_client_sdk::auth::Credentials;
+use polymarket_client_sdk::auth::{Credentials, ExposeSecret as _};
 use polymarket_client_sdk::clob::{Client, Config};
 use polymarket_client_sdk::error::{Synchronization, Validation};
 use reqwest::StatusCode;
@@ -217,4 +217,16 @@ async fn create_or_derive_api_key_should_succeed() -> anyhow::Result<()> {
     mock2.assert();
 
     Ok(())
+}
+
+#[test]
+fn credentials_secret_accessor_should_return_secret() {
+    let credentials = Credentials::new(API_KEY, SECRET.to_owned(), PASSPHRASE.to_owned());
+    assert_eq!(credentials.secret().expose_secret(), SECRET);
+}
+
+#[test]
+fn credentials_passphrase_accessor_should_return_passphrase() {
+    let credentials = Credentials::new(API_KEY, SECRET.to_owned(), PASSPHRASE.to_owned());
+    assert_eq!(credentials.passphrase().expose_secret(), PASSPHRASE);
 }


### PR DESCRIPTION
Unlike normal API credentials which can be re-derived via `derive_api_key`, builder credentials from `create_builder_api_key` cannot be recovered. This PR adds `secret()` and `passphrase()` accessor methods to `Credentials`, allowing users to persist these values for reuse.

Returns `&SecretString` to maintain security - callers must explicitly call `expose_secret()` to access the underlying value.

Also re-exports `SecretString` and `ExposeSecret` from `secrecy` so users don't need to add it as a dependency.

## Test plan
- [x] Added unit tests for `secret()` accessor
- [x] Added unit tests for `passphrase()` accessor
- [x] All existing tests pass