### PR TITLE
fix: handle order_type field in OpenOrderResponse

### DIFF
--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -314,7 +314,6 @@ pub struct OpenOrderResponse {
     pub created_at: DateTime<Utc>,
     #[serde_as(as = "TimestampSeconds<String>")]
     pub expiration: DateTime<Utc>,
-    #[serde(rename = "type")]
     pub order_type: OrderType,
 }
 

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -1503,7 +1503,7 @@ mod authenticated {
             "outcome": "YES",
             "created_at": 1_705_322_096,
             "expiration": "1705708800",
-            "type": "gtd"
+            "order_type": "gtd"
         });
 
         let mock = server.mock(|when, then| {
@@ -1566,7 +1566,7 @@ mod authenticated {
                     "outcome": "YES",
                     "created_at": 1_705_322_096,
                     "expiration": "1705708800",
-                    "type": "GTC"
+                    "order_type": "GTC"
                 }
             ],
             "limit": 1,


### PR DESCRIPTION
## Summary

The API now apparently returns `order_type` instead of `type` for the order type field in order responses. This was causing deserialization failures on the `/data/orders` endpoint with `missing field 'type'` errors.

- Removed incorrect `#[serde(rename = "type")]` from `OpenOrderResponse.order_type`
- Updated test fixtures to use `order_type` field name

## Test plan

- [x] All existing tests pass
- [x] Clippy clean
- [x] Verify against live API that order fetching works
