### PR TITLE
fix(types): improve type handling and API compatibility

### DIFF
--- a/src/bridge/types/response.rs
+++ b/src/bridge/types/response.rs
@@ -33,6 +33,8 @@ pub struct DepositAddresses {
 pub struct SupportedAssetsResponse {
     /// List of supported assets with minimum deposit amounts.
     pub supported_assets: Vec<SupportedAsset>,
+    /// Additional information about supported chains and assets.
+    pub note: Option<String>,
 }
 
 /// A supported asset with chain and token information.

--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -440,20 +440,22 @@ impl<S: State> Client<S> {
         &self,
         request: &PriceHistoryRequest,
     ) -> Result<PriceHistoryResponse> {
+        use crate::clob::types::TimeRange;
+
         let mut req = self
             .client()
             .request(Method::GET, format!("{}prices-history", self.host()))
             .query(&[("market", request.market.as_str())]);
 
-        if let Some(start_ts) = request.start_ts {
-            req = req.query(&[("startTs", start_ts)]);
+        match request.time_range {
+            TimeRange::Interval { interval } => {
+                req = req.query(&[("interval", interval.to_string())]);
+            }
+            TimeRange::Range { start_ts, end_ts } => {
+                req = req.query(&[("startTs", start_ts), ("endTs", end_ts)]);
+            }
         }
-        if let Some(end_ts) = request.end_ts {
-            req = req.query(&[("endTs", end_ts)]);
-        }
-        if let Some(interval) = &request.interval {
-            req = req.query(&[("interval", interval.to_string())]);
-        }
+
         if let Some(fidelity) = request.fidelity {
             req = req.query(&[("fidelity", fidelity)]);
         }

--- a/src/clob/types/mod.rs
+++ b/src/clob/types/mod.rs
@@ -106,6 +106,48 @@ pub enum Interval {
     Max,
 }
 
+/// Time range specification for price history queries.
+///
+/// The CLOB API requires either an interval or explicit start/end timestamps.
+/// This enum enforces that requirement at compile time.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(untagged)]
+pub enum TimeRange {
+    /// Use a predefined interval (e.g., last day, last week).
+    Interval {
+        /// The time interval.
+        interval: Interval,
+    },
+    /// Use explicit start and end timestamps.
+    Range {
+        /// Start timestamp (Unix seconds).
+        start_ts: i64,
+        /// End timestamp (Unix seconds).
+        end_ts: i64,
+    },
+}
+
+impl TimeRange {
+    /// Create a time range from a predefined interval.
+    #[must_use]
+    pub const fn from_interval(interval: Interval) -> Self {
+        Self::Interval { interval }
+    }
+
+    /// Create a time range from explicit timestamps.
+    #[must_use]
+    pub const fn from_range(start_ts: i64, end_ts: i64) -> Self {
+        Self::Range { start_ts, end_ts }
+    }
+}
+
+impl From<Interval> for TimeRange {
+    fn from(interval: Interval) -> Self {
+        Self::from_interval(interval)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum AmountInner {
     Usdc(Decimal),

--- a/src/clob/types/request.rs
+++ b/src/clob/types/request.rs
@@ -8,7 +8,7 @@ use chrono::NaiveDate;
 use serde::Serialize;
 use serde_with::{StringWithSeparator, formats::CommaSeparator, serde_as};
 
-use crate::clob::types::{AssetType, Interval, Side, SignatureType};
+use crate::clob::types::{AssetType, Side, SignatureType, TimeRange};
 use crate::types::Address;
 
 #[non_exhaustive]
@@ -55,13 +55,14 @@ pub struct LastTradePriceRequest {
 #[derive(Debug, Serialize, Builder)]
 #[builder(on(String, into))]
 pub struct PriceHistoryRequest {
+    /// The market (condition ID) to get price history for.
     pub market: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_ts: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_ts: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval: Option<Interval>,
+    /// The time range for the price history query.
+    /// Either a predefined interval or explicit start/end timestamps.
+    #[serde(flatten)]
+    #[builder(into)]
+    pub time_range: TimeRange,
+    /// Optional fidelity (number of data points).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fidelity: Option<u32>,
 }

--- a/src/gamma/types/response.rs
+++ b/src/gamma/types/response.rs
@@ -5,7 +5,9 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
+use crate::serde_helpers::StringFromAny;
 use crate::types::Decimal;
 
 /// Image optimization metadata.
@@ -99,13 +101,17 @@ pub struct Tag {
 }
 
 /// A relationship between tags.
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct RelatedTag {
+    #[serde_as(as = "StringFromAny")]
     pub id: String,
+    #[serde_as(as = "Option<StringFromAny>")]
     #[serde(rename = "tagID")]
     pub tag_id: Option<String>,
+    #[serde_as(as = "Option<StringFromAny>")]
     #[serde(rename = "relatedTagID")]
     pub related_tag_id: Option<String>,
     pub rank: Option<i32>,
@@ -211,6 +217,7 @@ pub struct Collection {
 }
 
 /// A prediction market event.
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -256,6 +263,11 @@ pub struct Event {
     pub featured_image: Option<String>,
     pub disqus_thread: Option<String>,
     pub parent_event: Option<String>,
+    #[serde_as(as = "Option<StringFromAny>")]
+    pub parent_event_id: Option<String>,
+    pub sportsradar_match_id: Option<String>,
+    #[serde_as(as = "Option<StringFromAny>")]
+    pub turn_provider_id: Option<String>,
     pub enable_order_book: Option<bool>,
     pub liquidity_amm: Option<Decimal>,
     pub liquidity_clob: Option<Decimal>,
@@ -310,6 +322,9 @@ pub struct Event {
     pub requires_translation: Option<bool>,
     pub neg_risk_augmented: Option<bool>,
     pub game_id: Option<i64>,
+    pub election_type: Option<String>,
+    pub country_name: Option<String>,
+    pub color: Option<String>,
 }
 
 /// A prediction market.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,12 @@ pub mod bridge;
 pub mod clob;
 #[cfg(feature = "data")]
 pub mod data;
-pub(crate) mod deser_warn;
 pub mod error;
 #[cfg(feature = "gamma")]
 pub mod gamma;
 #[cfg(feature = "rtds")]
 pub mod rtds;
+pub(crate) mod serde_helpers;
 pub mod types;
 
 use std::fmt::Write as _;
@@ -178,7 +178,7 @@ async fn request<Response: DeserializeOwned>(
     }
 
     let json_value = response.json::<serde_json::Value>().await?;
-    let response_data: Option<Response> = deser_warn::deserialize_with_warnings(json_value)?;
+    let response_data: Option<Response> = serde_helpers::deserialize_with_warnings(json_value)?;
 
     if let Some(response) = response_data {
         Ok(response)

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -1,10 +1,76 @@
-//! Deserialization with unknown field warnings.
+//! Serde helpers for flexible deserialization.
 //!
-//! When the `tracing` feature is enabled, this module logs warnings for any
+//! When the `tracing` feature is enabled, this module also logs warnings for any
 //! unknown fields encountered during deserialization, helping detect API changes.
 
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+
+/// A `serde_as` type that deserializes strings or integers as `String`.
+///
+/// Use with `#[serde_as(as = "StringFromAny")]` for `String` fields
+/// or `#[serde_as(as = "Option<StringFromAny>")]` for `Option<String>`.
+pub struct StringFromAny;
+
+impl<'de> serde_with::DeserializeAs<'de, String> for StringFromAny {
+    fn deserialize_as<D>(deserializer: D) -> std::result::Result<String, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use std::fmt;
+
+        use serde::de::{self, Visitor};
+
+        struct StringOrNumberVisitor;
+
+        impl Visitor<'_> for StringOrNumberVisitor {
+            type Value = String;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("string or integer")
+            }
+
+            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.to_owned())
+            }
+
+            fn visit_string<E>(self, v: String) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.to_string())
+            }
+
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(v.to_string())
+            }
+        }
+
+        deserializer.deserialize_any(StringOrNumberVisitor)
+    }
+}
+
+impl serde_with::SerializeAs<String> for StringFromAny {
+    fn serialize_as<S>(source: &String, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(source)
+    }
+}
 
 /// Deserialize JSON with unknown field warnings.
 ///
@@ -42,6 +108,13 @@ pub fn deserialize_with_warnings<T: DeserializeOwned>(value: Value) -> crate::Re
 
     let result: T = serde_ignored::deserialize(value, |path| {
         unknown_paths.push(path.to_string());
+    })
+    .inspect_err(|e| {
+        tracing::error!(
+            type_name = %type_name::<T>(),
+            error = %e,
+            "deserialization failed"
+        );
     })?;
 
     // Log warnings for unknown fields with their values
@@ -195,6 +268,148 @@ mod tests {
         assert_eq!(result.inner.value, 42);
     }
 
+    // ========== StringFromAny tests ==========
+
+    #[derive(Debug, Deserialize, PartialEq, serde::Serialize)]
+    struct StringFromAnyStruct {
+        #[serde(with = "serde_with::As::<StringFromAny>")]
+        id: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, serde::Serialize)]
+    struct OptionalStringFromAny {
+        #[serde(with = "serde_with::As::<Option<StringFromAny>>")]
+        id: Option<String>,
+    }
+
+    #[test]
+    fn string_from_any_deserialize_string() {
+        let json = serde_json::json!({ "id": "hello" });
+        let result: StringFromAnyStruct =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, "hello");
+    }
+
+    #[test]
+    fn string_from_any_deserialize_positive_integer() {
+        let json = serde_json::json!({ "id": 12345 });
+        let result: StringFromAnyStruct =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, "12345");
+    }
+
+    #[test]
+    fn string_from_any_deserialize_negative_integer() {
+        let json = serde_json::json!({ "id": -42 });
+        let result: StringFromAnyStruct =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, "-42");
+    }
+
+    #[test]
+    fn string_from_any_deserialize_zero() {
+        let json = serde_json::json!({ "id": 0 });
+        let result: StringFromAnyStruct =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, "0");
+    }
+
+    #[test]
+    fn string_from_any_deserialize_large_u64() {
+        // Test u64 max value
+        let json = serde_json::json!({ "id": u64::MAX });
+        let result: StringFromAnyStruct =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, u64::MAX.to_string());
+    }
+
+    #[test]
+    fn string_from_any_deserialize_large_negative_i64() {
+        // Test i64 min value
+        let json = serde_json::json!({ "id": i64::MIN });
+        let result: StringFromAnyStruct =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, i64::MIN.to_string());
+    }
+
+    #[test]
+    fn string_from_any_serialize_back_to_string() {
+        let obj = StringFromAnyStruct {
+            id: "12345".to_owned(),
+        };
+        let json = serde_json::to_value(&obj).expect("serialization failed");
+        assert_eq!(json, serde_json::json!({ "id": "12345" }));
+    }
+
+    #[test]
+    fn string_from_any_roundtrip_from_string() {
+        let json = serde_json::json!({ "id": "hello" });
+        let obj: StringFromAnyStruct =
+            serde_json::from_value(json).expect("deserialization failed");
+        let back = serde_json::to_value(&obj).expect("serialization failed");
+        assert_eq!(back, serde_json::json!({ "id": "hello" }));
+    }
+
+    #[test]
+    fn string_from_any_roundtrip_from_integer() {
+        let json = serde_json::json!({ "id": 42 });
+        let obj: StringFromAnyStruct =
+            serde_json::from_value(json).expect("deserialization failed");
+        // After roundtrip, integer becomes string
+        let back = serde_json::to_value(&obj).expect("serialization failed");
+        assert_eq!(back, serde_json::json!({ "id": "42" }));
+    }
+
+    #[test]
+    fn string_from_any_option_some_string() {
+        let json = serde_json::json!({ "id": "hello" });
+        let result: OptionalStringFromAny =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, Some("hello".to_owned()));
+    }
+
+    #[test]
+    fn string_from_any_option_some_integer() {
+        let json = serde_json::json!({ "id": 123 });
+        let result: OptionalStringFromAny =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, Some("123".to_owned()));
+    }
+
+    #[test]
+    fn string_from_any_option_none() {
+        let json = serde_json::json!({ "id": null });
+        let result: OptionalStringFromAny =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, None);
+    }
+
+    #[test]
+    fn string_from_any_option_serialize_some() {
+        let obj = OptionalStringFromAny {
+            id: Some("test".to_owned()),
+        };
+        let json = serde_json::to_value(&obj).expect("serialization failed");
+        assert_eq!(json, serde_json::json!({ "id": "test" }));
+    }
+
+    #[test]
+    fn string_from_any_option_serialize_none() {
+        let obj = OptionalStringFromAny { id: None };
+        let json = serde_json::to_value(&obj).expect("serialization failed");
+        assert_eq!(json, serde_json::json!({ "id": null }));
+    }
+
+    #[test]
+    fn string_from_any_empty_string() {
+        let json = serde_json::json!({ "id": "" });
+        let result: StringFromAnyStruct =
+            serde_json::from_value(json).expect("deserialization failed");
+        assert_eq!(result.id, "");
+    }
+
+    // ========== lookup_value tests ==========
+
     #[cfg(feature = "tracing")]
     #[test]
     fn lookup_simple_path() {
@@ -310,6 +525,23 @@ mod tests {
         // JSON object serialization order may vary, check both keys present
         assert!(formatted.contains("\"a\":1"));
         assert!(formatted.contains("\"b\":2"));
+    }
+
+    #[cfg(feature = "tracing")]
+    #[test]
+    fn format_none_shows_placeholder() {
+        let formatted = format_value(None);
+        assert_eq!(formatted, "<unable to retrieve>");
+    }
+
+    #[cfg(feature = "tracing")]
+    #[test]
+    fn lookup_option_marker_skipped() {
+        // serde_ignored uses '?' for Option wrappers
+        let json = serde_json::json!({"outer": {"inner": "value"}});
+        // Path "?.outer.?.inner" should skip ? markers
+        let result = lookup_value(&json, "?.outer.?.inner");
+        assert_eq!(result, Some(&Value::String("value".to_owned())));
     }
 
     /// Test that verifies warnings are actually emitted for unknown fields.


### PR DESCRIPTION
serde_helpers:
- Rename deser_warn module to serde_helpers for broader scope
- Add StringFromAny helper to handle APIs returning int or string

gamma:
- Fix RelatedTag fields (id, tagID, relatedTagID) to accept int or string
- Add missing Event fields: parentEventId, sportsradarMatchId, turnProviderId

clob:
- Fix TokenID to use StringFromAny
- Add TimeRange enum for type-safe price history queries
- Update PriceHistoryRequest to use TimeRange

bridge:
- Add note field to SupportedAssetsResponse

rtds:
- Fix parse_messages to handle empty/whitespace keepalive messages