### PR TITLE
feat(types): re-export commonly used external types for API ergonomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rtds = ["dep:backoff", "dep:tokio", "dep:tokio-tungstenite"]
 alloy = { version = "1.2.1", default-features = false, features = [
     "dyn-abi",
     "serde",
+    "signer-local",
     "signers",
     "sol-types"
 ] }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This crate provides strongly typed request builders, authenticated endpoints, `a
 - [Overview](#overview)
 - [Getting Started](#getting-started)
 - [Feature Flags](#feature-flags)
+- [Re-exported Types](#re-exported-types)
 - [Examples](#examples)
   - [CLOB Client](#clob-client)
   - [WebSocket Streaming](#websocket-streaming)
@@ -81,6 +82,41 @@ Enable features in your `Cargo.toml`:
 [dependencies]
 polymarket-client-sdk = { version = "0.3", features = ["ws", "data"] }
 ```
+
+## Re-exported Types
+
+This SDK re-exports commonly used types from external crates so you don't need to add them to your `Cargo.toml`:
+
+### From `types` module
+
+```rust
+use polymarket_client_sdk::types::{
+    Address, ChainId, Signature, address,  // from alloy::primitives
+    DateTime, NaiveDate, Utc,              // from chrono
+    Decimal, dec,                          // from rust_decimal + rust_decimal_macros
+};
+```
+
+### From `auth` module
+
+```rust
+use polymarket_client_sdk::auth::{
+    LocalSigner, Signer,          // from alloy::signers (LocalSigner + trait)
+    Uuid, ApiKey,                 // from uuid (ApiKey = Uuid)
+    SecretString, ExposeSecret,   // from secrecy
+    builder::Url,                 // from url (for remote builder config)
+};
+```
+
+### From `error` module
+
+```rust
+use polymarket_client_sdk::error::{
+    StatusCode, Method,           // from reqwest (for error inspection)
+};
+```
+
+This allows you to work with the SDK without managing version compatibility for these common dependencies.
 
 ## Examples
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,16 +1,26 @@
+// Re-exported types for public API convenience
+/// The [`Signer`] trait from alloy for signing operations.
+/// Implement this trait or use provided signers like [`LocalSigner`] or AWS KMS signers.
+pub use alloy::signers::Signer;
+/// Local wallet signer for signing with a private key.
+/// This is the most common signer implementation.
+pub use alloy::signers::local::LocalSigner;
 use async_trait::async_trait;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE;
 use hmac::{Hmac, Mac as _};
 use reqwest::header::HeaderMap;
 use reqwest::{Body, Request};
+/// Secret string types that redact values in debug output for security.
 pub use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use sha2::Sha256;
-use uuid::Uuid;
+/// UUID type used for API keys and identifiers.
+pub use uuid::Uuid;
 
 use crate::{Result, Timestamp};
 
+/// Type alias for API keys, which are UUIDs.
 pub type ApiKey = Uuid;
 
 /// Generic set of credentials used to authenticate to the Polymarket API. These credentials are
@@ -255,7 +265,8 @@ pub mod builder {
     use secrecy::ExposeSecret as _;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use url::Url;
+    /// URL type for remote builder host configuration.
+    pub use url::Url;
 
     use crate::auth::{Credentials, body_to_string, hmac, to_message};
     use crate::{Result, Timestamp};

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,11 @@ use std::fmt;
 use alloy::primitives::ChainId;
 use alloy::primitives::ruint::ParseError;
 use hmac::digest::InvalidLength;
-use reqwest::{Method, StatusCode, header};
+/// HTTP method type, re-exported for use with error inspection.
+pub use reqwest::Method;
+/// HTTP status code type, re-exported for use with error inspection.
+pub use reqwest::StatusCode;
+use reqwest::header;
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,2 +1,21 @@
-pub use alloy::primitives::{Address, address};
+//! Re-exported types from external crates for convenience.
+//!
+//! These types are commonly used in this SDK and are re-exported here
+//! so users don't need to add these dependencies to their `Cargo.toml`.
+
+/// Ethereum address type and the [`address!`] macro for compile-time address literals.
+/// [`ChainId`] is a type alias for `u64` representing EVM chain IDs.
+/// [`Signature`] represents cryptographic signatures for signed orders.
+pub use alloy::primitives::{Address, ChainId, Signature, address};
+/// Date and time types for timestamps in API responses and order expiration.
+pub use chrono::{DateTime, NaiveDate, Utc};
+/// Arbitrary precision decimal type for prices, sizes, and amounts.
 pub use rust_decimal::Decimal;
+/// Macro for creating [`Decimal`] literals at compile time.
+///
+/// # Example
+/// ```
+/// use polymarket_client_sdk::types::dec;
+/// let price = dec!(0.55);
+/// ```
+pub use rust_decimal_macros::dec;


### PR DESCRIPTION
## Summary

This PR improves the SDK's developer experience by re-exporting commonly used types from external dependencies. Users no longer need to manually add `alloy`, `rust_decimal`, `rust_decimal_macros`, `chrono`, `uuid`, or `secrecy` to their `Cargo.toml` just to work with types that appear in this SDK's public API.

This follows the pattern used by popular Rust libraries like `sqlx`, `axum`, and `reqwest`, which re-export types from their dependencies to provide a cohesive API surface.

## Changes

**Re-exports added:**
- `types`: `ChainId`, `Signature`, `DateTime`, `NaiveDate`, `Utc`, `dec!` macro
- `auth`: `LocalSigner`, `Signer` trait, `Uuid`
- `auth::builder`: `Url`
- `error`: `StatusCode`, `Method`

**Dependencies:**
- Added `signer-local` feature to alloy to support `LocalSigner` re-export

## Before/After

```toml
# Before - users needed these explicit dependencies
[dependencies]
alloy = { version = "1.2.1", features = ["signer-local"] }
rust_decimal = "1"
rust_decimal_macros = "1"
polymarket-client-sdk = "0.3"

# After - just the SDK
[dependencies]
polymarket-client-sdk = "0.3"
```