### PR TITLE
fix: add missing cumulativeMarkets field to Event struct

### DIFF
--- a/src/gamma/types/response.rs
+++ b/src/gamma/types/response.rs
@@ -325,6 +325,7 @@ pub struct Event {
     pub election_type: Option<String>,
     pub country_name: Option<String>,
     pub color: Option<String>,
+    pub cumulative_markets: Option<bool>,
 }
 
 /// A prediction market.


### PR DESCRIPTION
## Summary

Add missing `cumulativeMarkets` field to the `Event` struct to fix deserialization warning:

```
WARN polymarket_client_sdk::serde_helpers: unknown field in API response type_name=core::option::Option<alloc::vec::Vec<polymarket_client_sdk::gamma::types::response::Market>> field=?.19.events.?.0.cumulativeMarkets value=false
```

## Changes

- Added `cumulative_markets: Option<bool>` to `Event` struct in `src/gamma/types/response.rs`
