### PR TITLE
fix: wrong amount when trying to send market order with fractional size

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -1390,7 +1390,6 @@ impl<K: Kind> Client<Authenticated<K>> {
             expiration: None,
             taker: None,
             order_type: None,
-            rounding_strategy: None,
             client: Client {
                 inner: Arc::clone(&self.inner),
             },

--- a/src/clob/order_builder.rs
+++ b/src/clob/order_builder.rs
@@ -5,7 +5,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use alloy::primitives::U256;
 use chrono::{DateTime, Utc};
 use rand::Rng as _;
-use rust_decimal::RoundingStrategy;
 use rust_decimal::prelude::ToPrimitive as _;
 
 use crate::Result;
@@ -51,7 +50,6 @@ pub struct OrderBuilder<OrderKind, K: AuthKind> {
     pub(crate) taker: Option<Address>,
     pub(crate) order_type: Option<OrderType>,
     pub(crate) funder: Option<Address>,
-    pub(crate) rounding_strategy: Option<RoundingStrategy>,
     pub(crate) _kind: PhantomData<OrderKind>,
 }
 
@@ -258,17 +256,6 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
         self
     }
 
-    /// Sets the rounding strategy for this market order. Defaults to `MidpointAwayFromZero` if not specified.
-    ///
-    /// For market orders:
-    /// - `MidpointAwayFromZero`: Rounds up at midpoint (0.345 -> 0.35), more favorable for sellers
-    /// - `MidpointTowardZero`: Rounds down at midpoint (0.345 -> 0.34), more favorable for buyers
-    #[must_use]
-    pub fn rounding_strategy(mut self, rounding_strategy: RoundingStrategy) -> Self {
-        self.rounding_strategy = Some(rounding_strategy);
-        self
-    }
-
     // Attempts to calculate the market price from the top of the book for the particular token.
     // - Uses an orderbook depth search to find the cutoff price:
     //   - BUY + USDC: walk asks until notional >= USDC
@@ -284,15 +271,6 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
             .amount
             .as_ref()
             .expect("Amount was already validated in `build`");
-
-        // Get tick size to determine the correct precision for rounding
-        let minimum_tick_size = self
-            .client
-            .tick_size(token_id)
-            .await?
-            .minimum_tick_size
-            .as_decimal();
-        let decimals = minimum_tick_size.scale();
 
         let book = self
             .client
@@ -335,19 +313,13 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
             (sum >= amount.as_inner()).then_some(level.price)
         });
 
-        let rounding_strategy = self
-            .rounding_strategy
-            .unwrap_or(RoundingStrategy::MidpointAwayFromZero);
-
         match cutoff_price {
-            Some(price) => Ok(price.round_dp_with_strategy(decimals, rounding_strategy)),
+            Some(price) => Ok(price),
             None if matches!(order_type, OrderType::FOK) => Err(Error::validation(format!(
                 "Insufficient liquidity to fill order for {token_id} at {}",
                 amount.as_inner()
             ))),
-            None => Ok(first
-                .price
-                .round_dp_with_strategy(decimals, rounding_strategy)),
+            None => Ok(first.price),
         }
     }
 
@@ -537,33 +509,5 @@ mod tests {
         let masked_salt = to_ieee_754_int(raw_salt);
 
         assert!(masked_salt < (1 << 53));
-    }
-
-    #[test]
-    fn market_order_price_rounding_fixes_fractional_size_precision() {
-        // Polymarket backend API requires: maker amount max 2 decimals, taker amount max 4 decimals for market buy orders
-
-        // Test case 1: Price that rounds down with MidpointAwayFromZero (default strategy)
-        // 0.344999 -> 0.34
-        let unrounded_price_1 = dec!(0.344999);
-        let rounded_price_1 =
-            unrounded_price_1.round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero);
-        assert_eq!(rounded_price_1, dec!(0.34));
-        assert_eq!(rounded_price_1.scale(), 2);
-
-        // Test case 2: Price at midpoint - MidpointAwayFromZero rounds up
-        // 0.345000 -> 0.35
-        let unrounded_price_2 = dec!(0.345000);
-        let rounded_price_2 =
-            unrounded_price_2.round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero);
-        assert_eq!(rounded_price_2, dec!(0.35));
-        assert_eq!(rounded_price_2.scale(), 2);
-
-        // Test case 3: Price above midpoint - MidpointAwayFromZero rounds up
-        // 0.345001 -> 0.35
-        let unrounded_price_3 = dec!(0.345001);
-        let rounded_price_3 =
-            unrounded_price_3.round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero);
-        assert_eq!(rounded_price_3, dec!(0.35));
     }
 }


### PR DESCRIPTION
fixes https://github.com/Polymarket/rs-clob-client/issues/114

- This change does NOT alter public API behavior;
- Round off at the final order submission point