### PR TITLE
fix: add Yield enum option to ActivityType

### DIFF
--- a/src/data/types/mod.rs
+++ b/src/data/types/mod.rs
@@ -49,6 +49,8 @@ pub enum ActivityType {
     Reward,
     /// Converting between token types.
     Conversion,
+    /// Yield
+    Yield,
 }
 
 /// Sort criteria for position queries.


### PR DESCRIPTION
face this issue during testing
```
called `Result::unwrap()` on an `Err` value: Error { kind: Internal, source: Some(Error("unknown variant `YIELD`, expected one of `TRADE`, `SPLIT`, `MERGE`, `REDEEM`, `REWARD`, `CONVERSION`", line: 0, column: 0)), backtrace: <disabled> }
```
added the missing enum option