### PR TITLE
fix: suppress unused variable warnings in tracing cfg blocks

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -1524,6 +1524,8 @@ impl<K: Kind> Client<Authenticated<K>> {
                             Err(e) => {
                                 #[cfg(feature = "tracing")]
                                 error!("Unable to post heartbeat: {e:?}");
+                                #[cfg(not(feature = "tracing"))]
+                                let _ = &e;
                             }
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,11 +195,10 @@ pub trait ToQueryParams: Serialize {
     fn query_params(&self, next_cursor: Option<&str>) -> String {
         let mut params = serde_urlencoded::to_string(self)
             .inspect_err(|e| {
-                #[cfg(not(feature = "tracing"))]
-                let _: &serde_urlencoded::ser::Error = e;
-
                 #[cfg(feature = "tracing")]
                 tracing::error!("Unable to convert to URL-encoded string {e:?}");
+                #[cfg(not(feature = "tracing"))]
+                let _ = &e;
             })
             .unwrap_or_default();
 


### PR DESCRIPTION
Reorder and simplify tracing cfg patterns to fix warnings:
- Put #[cfg(feature = "tracing")] before #[cfg(not(feature = "tracing"))]
- Use simple `let _ = &e;` pattern for unused variable suppression