### PR TITLE
fix: add MakerRebate enum option to ActivityType

### DIFF
--- a/src/data/types/mod.rs
+++ b/src/data/types/mod.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::de::StdError;
 use serde::{Deserialize, Serialize};
-use serde_with::{formats::CommaSeparator, serde_as, StringWithSeparator};
+use serde_with::{StringWithSeparator, formats::CommaSeparator, serde_as};
 
 use crate::types::Decimal;
 


### PR DESCRIPTION
Was getting errors like this:

```
 Jan 08 02:16:57.779 [ERR] › fields.message="deserialization failed" fields.type-name=core::option::Option<alloc::vec::Vec<polymarket_client_sdk::data::types::response::Activity>> fields.error="unknown variant `MAKER_REBATE`, expected one of `TRADE`, `SPLIT`, `MERGE`, `REDEEM`, `REWARD`, `CONVERSION`" target=polymarket_client_sdk::serde_helpers
 Jan 08 02:16:57.780 [WRN] › fields.message="Failed to fetch activity" fields.error="Internal: unknown variant `MAKER_REBATE`, expected one of `TRADE`, `SPLIT`, `MERGE`, `REDEEM`, `REWARD`, `CONVERSION`" target=polymarket_bot::order::reconciliation
 ```