### PR TITLE
fix(rtds): serialize Chainlink filters as JSON string (#136)

### DIFF
--- a/examples/rtds_crypto_prices.rs
+++ b/examples/rtds_crypto_prices.rs
@@ -94,12 +94,14 @@ async fn main() -> anyhow::Result<()> {
         Err(e) => debug!(stream = "crypto_prices_filtered", error = %e),
     }
 
-    // Subscribe to Chainlink price feeds
+    // Subscribe to specific Chainlink symbol
+    let chainlink_symbol = "btc/usd".to_owned();
     info!(
         stream = "chainlink_prices",
-        "Subscribing to Chainlink price feeds"
+        symbol = %chainlink_symbol,
+        "Subscribing to Chainlink price feed"
     );
-    match client.subscribe_chainlink_prices(None) {
+    match client.subscribe_chainlink_prices(Some(chainlink_symbol)) {
         Ok(stream) => {
             let mut stream = Box::pin(stream);
             let mut count = 0;


### PR DESCRIPTION
The Chainlink RTDS endpoint expects filters to be a JSON string (escaped), while other endpoints like Binance crypto_prices expect raw JSON objects/arrays.

Before: "filters": {"symbol": "btc/usd"} (broken - server ignores filter)
After:  "filters": "{\"symbol\":\"btc/usd\"}" (works - server filters correctly)

Changes:
- Add topic-based conditional in Subscription serialization
- Update Chainlink test to verify escaped string format
- Add tests for edge cases (no filters, mixed subscri#ptions)
- Update example to test filtered Chainlink subscription

Closes #136 