### PR TITLE
feat(gamma): convert question_id fields to B256 type

### DIFF
--- a/src/gamma/types/request.rs
+++ b/src/gamma/types/request.rs
@@ -211,10 +211,10 @@ pub struct MarketsRequest {
     #[builder(default)]
     pub sports_market_types: Vec<String>,
     pub rewards_min_size: Option<Decimal>,
-    #[serde_as(as = "StringWithSeparator::<CommaSeparator, String>")]
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator, B256>")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
-    pub question_ids: Vec<String>,
+    pub question_ids: Vec<B256>,
     pub include_tag: Option<bool>,
     pub closed: Option<bool>,
 }

--- a/src/gamma/types/response.rs
+++ b/src/gamma/types/response.rs
@@ -386,8 +386,9 @@ pub struct Market {
     pub market_group: Option<i32>,
     pub group_item_title: Option<String>,
     pub group_item_threshold: Option<String>,
-    #[serde(rename = "questionID")]
-    pub question_id: Option<String>,
+    #[serde_as(as = "NoneAsEmptyString")]
+    #[serde(default, rename = "questionID")]
+    pub question_id: Option<B256>,
     pub uma_end_date: Option<String>,
     pub enable_order_book: Option<bool>,
     pub order_price_min_tick_size: Option<Decimal>,

--- a/tests/gamma.rs
+++ b/tests/gamma.rs
@@ -1269,7 +1269,10 @@ mod query_string {
             .game_id("game123".to_owned())
             .sports_market_types(vec!["moneyline".to_owned(), "spread".to_owned()])
             .rewards_min_size(dec!(100))
-            .question_ids(vec!["q1".to_owned(), "q2".to_owned()])
+            .question_ids(vec![
+                b256!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+                b256!("0x0000000000000000000000000000000000000000000000000000000000000002"),
+            ])
             .include_tag(true)
             .closed(false)
             .build();
@@ -1307,7 +1310,8 @@ mod query_string {
         assert!(qs.contains("game_id=game123"));
         assert!(qs.contains("sports_market_types=moneyline%2Cspread"));
         assert!(qs.contains("rewards_min_size=100"));
-        assert!(qs.contains("question_ids=q1%2Cq2"));
+        // B256 question_ids serialize to lowercase hex via serde (comma = %2C URL-encoded)
+        assert!(qs.contains("question_ids=0x0000000000000000000000000000000000000000000000000000000000000001%2C0x0000000000000000000000000000000000000000000000000000000000000002"));
         assert!(qs.contains("include_tag=true"));
         assert!(qs.contains("closed=false"));
     }


### PR DESCRIPTION
Extend the typed B256 work to cover question_id fields in Gamma:
- Market.question_id: Option<String> → Option<B256>
- MarketsRequest.question_ids: Vec<String> → Vec<B256>

Uses the same NoneAsEmptyString and StringWithSeparator patterns already established for condition_id fields.