### PR TITLE
feat(serde): add impl_unknown_enum_variant macro and integration tests

### DIFF
--- a/src/clob/types/mod.rs
+++ b/src/clob/types/mod.rs
@@ -59,6 +59,8 @@ pub enum OrderType {
     Unknown(String),
 }
 
+crate::impl_unknown_enum_variant!(OrderType, "OrderType");
+
 #[non_exhaustive]
 #[derive(
     Clone, Copy, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize,
@@ -304,6 +306,8 @@ pub enum OrderStatusType {
     Unknown(String),
 }
 
+crate::impl_unknown_enum_variant!(OrderStatusType, "OrderStatusType");
+
 #[non_exhaustive]
 #[derive(
     Clone, Debug, Default, Display, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize,
@@ -319,6 +323,8 @@ pub enum AssetType {
     Unknown(String),
 }
 
+crate::impl_unknown_enum_variant!(AssetType, "AssetType");
+
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
@@ -329,6 +335,8 @@ pub enum TraderSide {
     #[serde(untagged)]
     Unknown(String),
 }
+
+crate::impl_unknown_enum_variant!(TraderSide, "TraderSide");
 
 /// Represents the maximum number of decimal places for an order's price field
 #[non_exhaustive]

--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -154,6 +154,7 @@ pub struct OrderSummary {
 }
 
 #[non_exhaustive]
+#[serde_as]
 #[derive(Debug, Deserialize, Builder, PartialEq)]
 pub struct LastTradePriceResponse {
     pub price: Decimal,
@@ -161,6 +162,7 @@ pub struct LastTradePriceResponse {
 }
 
 #[non_exhaustive]
+#[serde_as]
 #[derive(Debug, Deserialize, Builder, PartialEq)]
 #[builder(on(String, into))]
 pub struct LastTradesPricesResponse {
@@ -288,6 +290,7 @@ pub struct PostOrderResponse {
     pub taking_amount: Decimal,
     #[serde(rename = "orderID")]
     pub order_id: String,
+    #[serde_as(as = "crate::serde_helpers::WarnOnUnknown<OrderStatusType>")]
     pub status: OrderStatusType,
     pub success: bool,
     /// On-chain transaction hashes for the order execution.
@@ -321,6 +324,7 @@ where
 #[builder(on(String, into))]
 pub struct OpenOrderResponse {
     pub id: String,
+    #[serde_as(as = "crate::serde_helpers::WarnOnUnknown<OrderStatusType>")]
     pub status: OrderStatusType,
     pub owner: ApiKey,
     pub maker_address: Address,
@@ -339,6 +343,7 @@ pub struct OpenOrderResponse {
     pub created_at: DateTime<Utc>,
     #[serde_as(as = "TimestampSeconds<String>")]
     pub expiration: DateTime<Utc>,
+    #[serde_as(as = "crate::serde_helpers::WarnOnUnknown<OrderType>")]
     pub order_type: OrderType,
 }
 
@@ -372,6 +377,7 @@ pub struct TradeResponse {
     pub size: Decimal,
     pub fee_rate_bps: Decimal,
     pub price: Decimal,
+    #[serde_as(as = "crate::serde_helpers::WarnOnUnknown<OrderStatusType>")]
     pub status: OrderStatusType,
     #[serde_as(as = "TimestampSeconds<String>")]
     pub match_time: DateTime<Utc>,
@@ -386,6 +392,7 @@ pub struct TradeResponse {
     pub maker_orders: Vec<MakerOrder>,
     /// On-chain transaction hash.
     pub transaction_hash: B256,
+    #[serde_as(as = "crate::serde_helpers::WarnOnUnknown<TraderSide>")]
     pub trader_side: TraderSide,
     #[serde(default)]
     pub error_msg: Option<String>,
@@ -400,6 +407,7 @@ pub struct NotificationResponse {
 }
 
 #[non_exhaustive]
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, Builder, PartialEq)]
 #[builder(on(String, into))]
 pub struct NotificationPayload {
@@ -429,6 +437,7 @@ pub struct NotificationPayload {
     /// On-chain transaction hash.
     pub transaction_hash: B256,
     #[serde(alias = "type")]
+    #[serde_as(as = "crate::serde_helpers::WarnOnUnknown<OrderType>")]
     pub order_type: OrderType,
 }
 
@@ -458,6 +467,7 @@ pub struct OrderScoringResponse {
 pub type OrdersScoringResponse = HashMap<String, bool>;
 
 #[non_exhaustive]
+#[serde_as]
 #[derive(Clone, Debug, Deserialize, Builder, PartialEq)]
 pub struct PriceSideResponse {
     pub side: Side,
@@ -507,6 +517,7 @@ pub struct UserInfo {
 }
 
 #[non_exhaustive]
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, Builder, PartialEq)]
 #[builder(on(String, into))]
 pub struct MakerOrder {
@@ -674,6 +685,7 @@ pub struct BuilderTradeResponse {
     pub size: Decimal,
     pub size_usdc: Decimal,
     pub price: Decimal,
+    #[serde_as(as = "crate::serde_helpers::WarnOnUnknown<OrderStatusType>")]
     pub status: OrderStatusType,
     pub outcome: String,
     pub outcome_index: u32,
@@ -762,6 +774,7 @@ pub struct ApproveRfqOrderResponse {
 /// An RFQ request in the system.
 #[cfg(feature = "rfq")]
 #[non_exhaustive]
+#[serde_as]
 #[derive(Debug, Clone, Deserialize, Builder, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[builder(on(String, into))]
@@ -793,6 +806,7 @@ pub struct RfqRequest {
 /// An RFQ quote in the system.
 #[cfg(feature = "rfq")]
 #[non_exhaustive]
+#[serde_as]
 #[derive(Debug, Clone, Deserialize, Builder, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[builder(on(String, into))]

--- a/src/clob/ws/types/response.rs
+++ b/src/clob/ws/types/response.rs
@@ -113,6 +113,7 @@ pub struct PriceChange {
 }
 
 #[non_exhaustive]
+#[serde_as]
 #[derive(Debug, Clone, Deserialize)]
 pub struct PriceChangeBatchEntry {
     /// Asset/token identifier
@@ -353,11 +354,13 @@ pub struct TradeMessage {
     pub transaction_hash: Option<B256>,
     /// Whether user was maker or taker
     #[serde(default)]
+    #[serde_as(as = "Option<crate::serde_helpers::WarnOnUnknown<TraderSide>>")]
     pub trader_side: Option<TraderSide>,
 }
 
 /// User order update message (authenticated channel only).
 #[non_exhaustive]
+#[serde_as]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OrderMessage {
     /// Order identifier
@@ -419,6 +422,8 @@ pub enum OrderStatus {
     #[serde(untagged)]
     Unknown(String),
 }
+
+crate::impl_unknown_enum_variant!(OrderStatus, "ws::OrderStatus");
 
 /// Calculated midpoint update (derived from orderbook).
 #[non_exhaustive]

--- a/src/data/types/mod.rs
+++ b/src/data/types/mod.rs
@@ -26,6 +26,8 @@ pub enum Side {
     Unknown(String),
 }
 
+crate::impl_unknown_enum_variant!(Side, "data::Side");
+
 /// The type of on-chain activity for a user.
 ///
 /// Activities represent various operations that users can perform on the Polymarket protocol.
@@ -54,6 +56,8 @@ pub enum ActivityType {
     #[serde(untagged)]
     Unknown(String),
 }
+
+crate::impl_unknown_enum_variant!(ActivityType, "ActivityType");
 
 /// Sort criteria for position queries.
 ///

--- a/src/data/types/response.rs
+++ b/src/data/types/response.rs
@@ -155,6 +155,7 @@ pub struct ClosedPosition {
 ///
 /// Returned by the `/trades` endpoint. Represents an executed order where
 /// outcome tokens were bought or sold.
+#[serde_as]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -162,6 +163,7 @@ pub struct Trade {
     /// The trader's proxy wallet address.
     pub proxy_wallet: Address,
     /// Trade side (BUY or SELL).
+    #[serde_as(as = "crate::serde_helpers::WarnOnUnknown<Side>")]
     pub side: Side,
     /// The outcome token asset identifier (decimal string from API).
     pub asset: String,
@@ -203,6 +205,7 @@ pub struct Trade {
 ///
 /// Returned by the `/activity` endpoint. Represents various on-chain operations
 /// including trades, splits, merges, redemptions, rewards, and conversions.
+#[serde_as]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -215,6 +218,7 @@ pub struct Activity {
     pub condition_id: B256,
     /// Type of activity (TRADE, SPLIT, MERGE, REDEEM, REWARD, CONVERSION).
     #[serde(rename = "type")]
+    #[serde_as(as = "crate::serde_helpers::WarnOnUnknown<ActivityType>")]
     pub activity_type: ActivityType,
     /// Number of tokens involved in the activity.
     pub size: Decimal,

--- a/src/gamma/types/mod.rs
+++ b/src/gamma/types/mod.rs
@@ -46,6 +46,8 @@ pub enum RelatedTagsStatus {
     Unknown(String),
 }
 
+crate::impl_unknown_enum_variant!(RelatedTagsStatus, "RelatedTagsStatus");
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum_macros::Display)]
 #[non_exhaustive]
 pub enum ParentEntityType {
@@ -58,3 +60,5 @@ pub enum ParentEntityType {
     #[serde(untagged)]
     Unknown(String),
 }
+
+crate::impl_unknown_enum_variant!(ParentEntityType, "ParentEntityType");

--- a/src/rtds/types/response.rs
+++ b/src/rtds/types/response.rs
@@ -150,6 +150,8 @@ pub enum CommentType {
     Unknown(String),
 }
 
+crate::impl_unknown_enum_variant!(CommentType, "CommentType");
+
 /// Deserialize messages from the byte slice.
 ///
 /// Handles both single objects and arrays of messages.

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -2,6 +2,20 @@
 //!
 //! When the `tracing` feature is enabled, this module also logs warnings for any
 //! unknown fields encountered during deserialization, helping detect API changes.
+//!
+//! ## Unknown Enum Variant Warnings
+//!
+//! The [`WarnOnUnknown`] wrapper type can be used with `serde_as` to emit warnings when
+//! an enum deserializes to its `Unknown(String)` variant. This helps detect when the API
+//! starts sending new values that the library doesn't explicitly handle.
+//!
+//! ```ignore
+//! #[serde_as]
+//! struct Response {
+//!     #[serde_as(as = "WarnOnUnknown<OrderType>")]
+//!     order_type: OrderType,
+//! }
+//! ```
 
 #[cfg(any(
     feature = "bridge",
@@ -77,6 +91,153 @@ impl serde_with::SerializeAs<String> for StringFromAny {
         S: serde::Serializer,
     {
         serializer.serialize_str(source)
+    }
+}
+
+/// Trait for enums that have an `Unknown(String)` variant to capture unrecognized values.
+///
+/// Implementing this trait allows the enum to be used with [`WarnOnUnknown`] to emit
+/// warnings when an unknown variant is deserialized from the API.
+///
+/// # Example
+///
+/// ```ignore
+/// #[derive(Deserialize)]
+/// enum OrderType {
+///     GTC,
+///     FOK,
+///     #[serde(untagged)]
+///     Unknown(String),
+/// }
+///
+/// impl UnknownEnumVariant for OrderType {
+///     fn as_unknown(&self) -> Option<&str> {
+///         match self {
+///             OrderType::Unknown(s) => Some(s),
+///             _ => None,
+///         }
+///     }
+///     fn type_name() -> &'static str { "OrderType" }
+/// }
+/// ```
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma"
+))]
+pub trait UnknownEnumVariant {
+    /// Returns the unknown value if this is an `Unknown` variant, otherwise `None`.
+    fn as_unknown(&self) -> Option<&str>;
+
+    /// Returns the name of this enum type for logging purposes.
+    fn type_name() -> &'static str;
+}
+
+/// Implements [`UnknownEnumVariant`] for an enum with an `Unknown(String)` variant.
+///
+/// # Example
+///
+/// ```ignore
+/// impl_unknown_enum_variant!(OrderType, "OrderType");
+/// ```
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma"
+))]
+#[macro_export]
+macro_rules! impl_unknown_enum_variant {
+    ($enum_name:ident, $type_name:literal) => {
+        impl $crate::serde_helpers::UnknownEnumVariant for $enum_name {
+            fn as_unknown(&self) -> Option<&str> {
+                match self {
+                    $enum_name::Unknown(s) => Some(s),
+                    _ => None,
+                }
+            }
+
+            fn type_name() -> &'static str {
+                $type_name
+            }
+        }
+    };
+}
+
+/// A `serde_as` wrapper that logs a warning when an enum deserializes to its `Unknown` variant.
+///
+/// Use with `#[serde_as(as = "WarnOnUnknown<EnumType>")]` on struct fields.
+/// When the `tracing` feature is disabled, this is a no-op passthrough.
+///
+/// # Example
+///
+/// ```ignore
+/// use serde_with::serde_as;
+///
+/// #[serde_as]
+/// #[derive(Deserialize)]
+/// struct Response {
+///     #[serde_as(as = "WarnOnUnknown<OrderType>")]
+///     order_type: OrderType,
+/// }
+/// ```
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma"
+))]
+pub struct WarnOnUnknown<T>(std::marker::PhantomData<T>);
+
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma"
+))]
+impl<'de, T> serde_with::DeserializeAs<'de, T> for WarnOnUnknown<T>
+where
+    T: serde::Deserialize<'de> + UnknownEnumVariant,
+{
+    fn deserialize_as<D>(deserializer: D) -> std::result::Result<T, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = T::deserialize(deserializer)?;
+
+        #[cfg(feature = "tracing")]
+        if let Some(unknown_value) = value.as_unknown() {
+            tracing::warn!(
+                enum_type = T::type_name(),
+                unknown_value = %unknown_value,
+                "unknown enum variant in API response"
+            );
+        }
+
+        // Silence unused variable warning when tracing is disabled
+        #[cfg(not(feature = "tracing"))]
+        let _ = &value;
+
+        Ok(value)
+    }
+}
+
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma"
+))]
+impl<T> serde_with::SerializeAs<T> for WarnOnUnknown<T>
+where
+    T: serde::Serialize,
+{
+    fn serialize_as<S>(source: &T, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        source.serialize(serializer)
     }
 }
 
@@ -727,5 +888,132 @@ mod tests {
         // Path "?.outer.?.inner" should skip ? markers
         let result = lookup_value(&json, "?.outer.?.inner");
         assert_eq!(result, Some(&Value::String("value".to_owned())));
+    }
+
+    // ========== WarnOnUnknown tests ==========
+    #[cfg(any(
+        feature = "bridge",
+        feature = "clob",
+        feature = "data",
+        feature = "gamma"
+    ))]
+    mod warn_on_unknown_tests {
+        use serde::Deserialize;
+        use serde_with::serde_as;
+
+        use super::super::{UnknownEnumVariant as _, WarnOnUnknown};
+
+        /// Test enum with an Unknown variant
+        #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+        #[serde(rename_all = "UPPERCASE")]
+        enum TestOrderType {
+            Gtc,
+            Fok,
+            #[serde(untagged)]
+            Unknown(String),
+        }
+
+        crate::impl_unknown_enum_variant!(TestOrderType, "TestOrderType");
+
+        #[serde_as]
+        #[derive(Debug, Deserialize)]
+        struct TestResponse {
+            #[serde_as(as = "WarnOnUnknown<TestOrderType>")]
+            order_type: TestOrderType,
+        }
+
+        #[test]
+        fn warn_on_unknown_deserialize_known_variant() {
+            let json = serde_json::json!({ "order_type": "GTC" });
+            let result: TestResponse =
+                serde_json::from_value(json).expect("deserialization failed");
+            assert_eq!(result.order_type, TestOrderType::Gtc);
+        }
+
+        #[test]
+        fn warn_on_unknown_deserialize_unknown_variant() {
+            let json = serde_json::json!({ "order_type": "NEW_TYPE" });
+            let result: TestResponse =
+                serde_json::from_value(json).expect("deserialization failed");
+            assert_eq!(
+                result.order_type,
+                TestOrderType::Unknown("NEW_TYPE".to_owned())
+            );
+        }
+
+        #[test]
+        fn unknown_enum_variant_trait_returns_none_for_known() {
+            let gtc = TestOrderType::Gtc;
+            assert_eq!(gtc.as_unknown(), None);
+        }
+
+        #[test]
+        fn unknown_enum_variant_trait_returns_some_for_unknown() {
+            let unknown = TestOrderType::Unknown("MYSTERY".to_owned());
+            assert_eq!(unknown.as_unknown(), Some("MYSTERY"));
+        }
+
+        /// Test that verifies warnings are actually emitted for unknown enum variants.
+        #[cfg(feature = "tracing")]
+        #[test]
+        fn warning_is_emitted_for_unknown_enum_variant() {
+            use std::sync::{Arc, Mutex};
+
+            use tracing_subscriber::layer::SubscriberExt as _;
+
+            // Capture warnings in a buffer
+            let warnings: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+            let warnings_clone = Arc::clone(&warnings);
+
+            // Custom layer that captures warn events
+            let layer = tracing_subscriber::fmt::layer()
+                .with_writer(move || {
+                    struct CaptureWriter(Arc<Mutex<Vec<String>>>);
+                    impl std::io::Write for CaptureWriter {
+                        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                            if let Ok(s) = std::str::from_utf8(buf) {
+                                self.0.lock().expect("lock").push(s.to_owned());
+                            }
+                            Ok(buf.len())
+                        }
+                        fn flush(&mut self) -> std::io::Result<()> {
+                            Ok(())
+                        }
+                    }
+                    CaptureWriter(Arc::clone(&warnings_clone))
+                })
+                .with_ansi(false);
+
+            let subscriber = tracing_subscriber::registry().with(layer);
+
+            // Run the deserialization with our subscriber
+            tracing::subscriber::with_default(subscriber, || {
+                let json = serde_json::json!({ "order_type": "BRAND_NEW_TYPE" });
+
+                let result: TestResponse =
+                    serde_json::from_value(json).expect("deserialization should succeed");
+                assert_eq!(
+                    result.order_type,
+                    TestOrderType::Unknown("BRAND_NEW_TYPE".to_owned())
+                );
+            });
+
+            // Check that warnings were captured
+            let captured = warnings.lock().expect("lock");
+            let all_output = captured.join("");
+
+            assert!(
+                all_output.contains("unknown enum variant"),
+                "Expected 'unknown enum variant' in output, got: {all_output}"
+            );
+            assert!(
+                all_output.contains("BRAND_NEW_TYPE"),
+                "Expected 'BRAND_NEW_TYPE' in output, got: {all_output}"
+            );
+            assert!(
+                all_output.contains("TestOrderType"),
+                "Expected 'TestOrderType' in output, got: {all_output}"
+            );
+        }
     }
 }

--- a/tests/deserialization_warnings.rs
+++ b/tests/deserialization_warnings.rs
@@ -1,0 +1,175 @@
+//! Integration tests for deserialization warning system.
+//!
+//! Tests that the library correctly emits warnings/errors for:
+//! 1. Unknown fields in API responses
+//! 2. Type mismatch errors
+//! 3. Unknown enum variants
+
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+use httpmock::MockServer;
+use polymarket_client_sdk::clob::{Client as ClobClient, Config};
+use polymarket_client_sdk::data::Client as DataClient;
+use polymarket_client_sdk::types::address;
+use serde_json::json;
+use tracing_subscriber::layer::SubscriberExt as _;
+
+/// Captures tracing output for assertion.
+fn with_captured_logs<F, Fut, R>(f: F) -> (R, String)
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = R>,
+{
+    let logs: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let logs_clone = Arc::clone(&logs);
+
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(move || {
+            struct CaptureWriter(Arc<Mutex<Vec<String>>>);
+            impl std::io::Write for CaptureWriter {
+                fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                    if let Ok(s) = std::str::from_utf8(buf) {
+                        self.0.lock().expect("lock").push(s.to_owned());
+                    }
+                    Ok(buf.len())
+                }
+                fn flush(&mut self) -> std::io::Result<()> {
+                    Ok(())
+                }
+            }
+            CaptureWriter(Arc::clone(&logs_clone))
+        })
+        .with_ansi(false);
+
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    let result = tracing::subscriber::with_default(subscriber, || {
+        // We need to block on the future within the subscriber context
+        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(f()))
+    });
+
+    let captured = logs.lock().expect("lock").join("");
+
+    (result, captured)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unknown_field_emits_warning() {
+    let server = MockServer::start();
+    let client = ClobClient::new(&server.base_url(), Config::default()).unwrap();
+
+    let mock = server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path("/midpoint")
+            .query_param("token_id", "123");
+        then.status(200).json_body(json!({
+            "mid": "0.55",
+            "new_api_field": "some_value",
+        }));
+    });
+
+    let (result, logs) = with_captured_logs(|| async {
+        client
+            .midpoint(
+                &polymarket_client_sdk::clob::types::request::MidpointRequest::builder()
+                    .token_id("123")
+                    .build(),
+            )
+            .await
+    });
+
+    mock.assert();
+    assert!(result.is_ok(), "request should succeed");
+    assert!(
+        logs.contains("unknown field"),
+        "expected 'unknown field' warning, got: {logs}"
+    );
+    assert!(
+        logs.contains("new_api_field"),
+        "expected field name in warning, got: {logs}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn type_mismatch_emits_error() {
+    let server = MockServer::start();
+    let client = ClobClient::new(&server.base_url(), Config::default()).unwrap();
+
+    let mock = server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path("/midpoint")
+            .query_param("token_id", "456");
+        // Send an object where a decimal string is expected
+        then.status(200)
+            .json_body(json!({ "mid": { "invalid": "type" } }));
+    });
+
+    let (result, logs) = with_captured_logs(|| async {
+        client
+            .midpoint(
+                &polymarket_client_sdk::clob::types::request::MidpointRequest::builder()
+                    .token_id("456")
+                    .build(),
+            )
+            .await
+    });
+
+    mock.assert();
+    assert!(result.is_err(), "request should fail due to type mismatch");
+    assert!(
+        logs.contains("deserialization failed"),
+        "expected 'deserialization failed' error, got: {logs}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unknown_enum_variant_emits_warning() {
+    let server = MockServer::start();
+    let client = DataClient::new(&server.base_url()).unwrap();
+
+    let user_addr = address!("0x1234567890123456789012345678901234567890");
+
+    let mock = server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path("/trades")
+            .query_param("user", "0x1234567890123456789012345678901234567890");
+        then.status(200).json_body(json!([{
+            "proxyWallet": "0x1234567890123456789012345678901234567890",
+            "side": "NEW_SIDE_TYPE",
+            "asset": "12345",
+            "conditionId": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917",
+            "size": "10.0",
+            "price": "0.50",
+            "timestamp": 1_700_000_000,
+            "title": "Test Market",
+            "slug": "test-market",
+            "icon": "https://example.com/icon.png",
+            "eventSlug": "test-event",
+            "outcome": "Yes",
+            "outcomeIndex": 0,
+            "transactionHash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        }]));
+    });
+
+    let (result, logs) = with_captured_logs(|| async {
+        client
+            .trades(
+                &polymarket_client_sdk::data::types::request::TradesRequest::builder()
+                    .user(user_addr)
+                    .build(),
+            )
+            .await
+    });
+
+    mock.assert();
+    assert!(result.is_ok(), "request should succeed");
+    assert!(
+        logs.contains("unknown enum variant"),
+        "expected 'unknown enum variant' warning, got: {logs}"
+    );
+    assert!(
+        logs.contains("NEW_SIDE_TYPE"),
+        "expected unknown value in warning, got: {logs}"
+    );
+}


### PR DESCRIPTION
- Add `impl_unknown_enum_variant!` macro to reduce boilerplate for enums with `Unknown(String)` variants
- Replace 10 manual `UnknownEnumVariant` trait implementations with macro calls across clob, data, gamma, and rtds modules
- Add `WarnOnUnknown<T>` serde_as wrapper annotations to response types
- Add integration tests for deserialization warnings:
  - Unknown field warnings
  - Type mismatch errors
  - Unknown enum variant warnings

```
2026-01-09T01:31:51.148899Z  INFO httpmock::server::server: Listening on 127.0.0.1:0
2026-01-09T01:31:51.183095Z  INFO deserialization_warnings: complete deserialization with no warnings scenario=1
2026-01-09T01:31:51.185606Z  INFO deserialization_warnings: unknown field warning (watch for WARN from library) scenario=2
2026-01-09T01:31:51.186144Z  WARN polymarket_client_sdk::serde_helpers: unknown field in API response type_name=core::option::Option<polymarket_client_sdk::clob::types::response::MidpointResponse> field=?.new_api_field value="some_value"
2026-01-09T01:31:51.186171Z  INFO deserialization_warnings: type mismatch error (watch for ERROR from library) scenario=3
2026-01-09T01:31:51.186675Z ERROR polymarket_client_sdk::serde_helpers: deserialization failed type_name=core::option::Option<polymarket_client_sdk::clob::types::response::MidpointResponse> path=mid value={"invalid":"type"} error=invalid type: map, expected a Decimal type representing a fixed-point number at line 1 column 8
2026-01-09T01:31:51.186735Z  INFO deserialization_warnings: unknown enum variant warning (watch for WARN from library) scenario=4
2026-01-09T01:31:51.187559Z  WARN polymarket_client_sdk::serde_helpers: unknown enum variant in API response enum_type="data::Side" unknown_value=NEW_SIDE_TYPE
```

Closes #141