### PR TITLE
feat(Data): update request types

### DIFF
--- a/src/data/types/request.rs
+++ b/src/data/types/request.rs
@@ -66,6 +66,7 @@ fn validate_bound(
 ///     .sort_direction(SortDirection::Desc)
 ///     .build();
 /// ```
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Builder, Serialize)]
 #[non_exhaustive]
@@ -73,6 +74,16 @@ pub struct PositionsRequest {
     /// User address (required).
     #[builder(into)]
     pub user: Address,
+    /// Comma-separated list of condition IDs. Mutually exclusive with eventId. 0x-prefixed 64-hex string
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator,B256>")]
+    #[builder(default)]
+    #[serde(rename = "market", skip_serializing_if = "Vec::is_empty")]
+    pub markets: Vec<B256>,
+    /// Comma-separated list of event IDs. Mutually exclusive with market. Required range: x >= 1
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator,i32>")]
+    #[builder(default)]
+    #[serde(rename = "eventId", skip_serializing_if = "Vec::is_empty")]
+    pub event_id: Vec<i32>,
     /// Filter by markets or events. Mutually exclusive options.
     #[serde(flatten, skip_serializing_if = "filter_is_none_or_empty")]
     pub filter: Option<MarketFilter>,
@@ -137,6 +148,7 @@ fn filter_is_none_or_empty(f: &Option<MarketFilter>) -> bool {
 ///     .trade_filter(TradeFilter::cash(dec!(100)).unwrap())
 ///     .build();
 /// ```
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Builder, Default, Serialize)]
 #[non_exhaustive]
@@ -161,6 +173,16 @@ pub struct TradesRequest {
     pub trade_filter: Option<TradeFilter>,
     /// Filter by trade side (BUY or SELL).
     pub side: Option<Side>,
+    /// Comma-separated list of condition IDs. Mutually exclusive with eventId. 0x-prefixed 64-hex string
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator,B256>")]
+    #[builder(default)]
+    #[serde(rename = "market", skip_serializing_if = "Vec::is_empty")]
+    pub markets: Vec<B256>,
+    /// Comma-separated list of event IDs. Mutually exclusive with market. Required range: x >= 1
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator,i32>")]
+    #[builder(default)]
+    #[serde(rename = "eventId", skip_serializing_if = "Vec::is_empty")]
+    pub event_id: Vec<i32>,
 }
 
 /// Request parameters for the `/activity` endpoint.
@@ -229,6 +251,16 @@ pub struct ActivityRequest {
     pub sort_direction: Option<SortDirection>,
     /// Filter by trade side (only applies to TRADE activities).
     pub side: Option<Side>,
+    /// Comma-separated list of condition IDs. Mutually exclusive with eventId. 0x-prefixed 64-hex string
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator,B256>")]
+    #[builder(default)]
+    #[serde(rename = "market", skip_serializing_if = "Vec::is_empty")]
+    pub markets: Vec<B256>,
+    /// Comma-separated list of event IDs. Mutually exclusive with market. Required range: x >= 1
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator,i32>")]
+    #[builder(default)]
+    #[serde(rename = "eventId", skip_serializing_if = "Vec::is_empty")]
+    pub event_id: Vec<i32>,
 }
 
 /// Request parameters for the `/holders` endpoint.
@@ -379,6 +411,7 @@ pub struct LiveVolumeRequest {
 ///     .sort_by(ClosedPositionSortBy::Timestamp)
 ///     .build();
 /// ```
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Builder, Serialize)]
 #[non_exhaustive]
@@ -404,6 +437,16 @@ pub struct ClosedPositionsRequest {
     /// Sort direction (default: DESC).
     #[serde(rename = "sortDirection")]
     pub sort_direction: Option<SortDirection>,
+    /// Comma-separated list of condition IDs. Mutually exclusive with eventId. 0x-prefixed 64-hex string
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator,B256>")]
+    #[builder(default)]
+    #[serde(rename = "market", skip_serializing_if = "Vec::is_empty")]
+    pub markets: Vec<B256>,
+    /// Comma-separated list of event IDs. Mutually exclusive with market. Required range: x >= 1
+    #[serde_as(as = "StringWithSeparator::<CommaSeparator,i32>")]
+    #[builder(default)]
+    #[serde(rename = "eventId", skip_serializing_if = "Vec::is_empty")]
+    pub event_id: Vec<i32>,
 }
 
 /// Request parameters for the `/v1/builders/leaderboard` endpoint.

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -42,6 +42,7 @@ mod health {
 }
 
 mod positions {
+    use alloy::primitives::b256;
     use httpmock::{Method::GET, MockServer};
     use polymarket_client_sdk::data::{Client, types::request::PositionsRequest};
     use reqwest::StatusCode;
@@ -126,6 +127,61 @@ mod positions {
             .limit(10)?
             .offset(5)?
             .redeemable(true)
+            .build();
+
+        let response = client.positions(&request).await?;
+
+        assert!(response.is_empty());
+        mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn positions_with_markets_should_succeed() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = Client::new(&server.base_url())?;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/positions")
+                .query_param("user", "0x1234567890abcdef1234567890abcdef12345678")
+                .query_param("market", "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917,0xaa22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917");
+            then.status(StatusCode::OK).json_body(json!([]));
+        });
+
+        let request = PositionsRequest::builder()
+            .user(test_user())
+            .markets(vec![
+                b256!("dd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917"),
+                b256!("aa22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917"),
+            ])
+            .build();
+
+        let response = client.positions(&request).await?;
+
+        assert!(response.is_empty());
+        mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn positions_with_event_id_should_succeed() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = Client::new(&server.base_url())?;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/positions")
+                .query_param("user", "0x1234567890abcdef1234567890abcdef12345678")
+                .query_param("eventId", "1,2,3");
+            then.status(StatusCode::OK).json_body(json!([]));
+        });
+
+        let request = PositionsRequest::builder()
+            .user(test_user())
+            .event_id(vec![1, 2, 3])
             .build();
 
         let response = client.positions(&request).await?;


### PR DESCRIPTION
Updates the Data client to include the market and eventId params for requests to the positions, activity, trades, and closed-positions endpoints. Also adds two tests for the positions endpoint to ensure that both fields are being serialized correctly. 