### PR TITLE
chore(ctf): add Builder to non_exhaustive response structs

### DIFF
--- a/src/ctf/types/response.rs
+++ b/src/ctf/types/response.rs
@@ -1,10 +1,11 @@
 //! Response types for CTF operations.
 
 use alloy::primitives::{B256, U256};
+use bon::Builder;
 
 /// Response from calculating a condition ID.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
 pub struct ConditionIdResponse {
     /// The calculated condition ID
     pub condition_id: B256,
@@ -12,7 +13,7 @@ pub struct ConditionIdResponse {
 
 /// Response from calculating a collection ID.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
 pub struct CollectionIdResponse {
     /// The calculated collection ID
     pub collection_id: B256,
@@ -20,7 +21,7 @@ pub struct CollectionIdResponse {
 
 /// Response from calculating a position ID.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
 pub struct PositionIdResponse {
     /// The calculated position ID (ERC1155 token ID)
     pub position_id: U256,
@@ -28,7 +29,7 @@ pub struct PositionIdResponse {
 
 /// Response from a split position transaction.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
 pub struct SplitPositionResponse {
     /// Transaction hash
     pub transaction_hash: B256,
@@ -38,7 +39,7 @@ pub struct SplitPositionResponse {
 
 /// Response from a merge positions transaction.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
 pub struct MergePositionsResponse {
     /// Transaction hash
     pub transaction_hash: B256,
@@ -48,7 +49,7 @@ pub struct MergePositionsResponse {
 
 /// Response from a redeem positions transaction.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
 pub struct RedeemPositionsResponse {
     /// Transaction hash
     pub transaction_hash: B256,
@@ -58,7 +59,7 @@ pub struct RedeemPositionsResponse {
 
 /// Response from a `NegRisk` redeem transaction.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
 pub struct RedeemNegRiskResponse {
     /// Transaction hash
     pub transaction_hash: B256,


### PR DESCRIPTION
Enables users to construct CTF response types for testing.