### PR TITLE
fix(data): make Activity.condition_id optional

### DIFF
--- a/src/data/types/response.rs
+++ b/src/data/types/response.rs
@@ -240,7 +240,10 @@ pub struct Activity {
     /// Unix timestamp when the activity occurred.
     pub timestamp: i64,
     /// The market condition ID (unique market identifier).
-    pub condition_id: B256,
+    /// Can be empty for some activity types (e.g., rewards, conversions).
+    #[serde(default)]
+    #[serde_as(as = "NoneAsEmptyString")]
+    pub condition_id: Option<B256>,
     /// Type of activity (TRADE, SPLIT, MERGE, REDEEM, REWARD, CONVERSION).
     #[serde(rename = "type")]
     pub activity_type: ActivityType,

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -250,7 +250,7 @@ mod activity {
 
         assert_eq!(response.len(), 2);
         assert_eq!(response[0].proxy_wallet, test_user());
-        assert_eq!(response[0].condition_id, test_condition_id());
+        assert_eq!(response[0].condition_id, Some(test_condition_id()));
         assert_eq!(response[0].activity_type, ActivityType::Trade);
         assert_eq!(response[0].side, Some(Side::Buy));
         assert_eq!(response[1].activity_type, ActivityType::Redeem);


### PR DESCRIPTION
The Polymarket API returns empty conditionId for some activity types (e.g., rewards, conversions). This caused deserialization failures.

Use NoneAsEmptyString to handle empty strings gracefully.