### PR TITLE
fix(clob): usage of ampersand before and without question mark

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -1798,7 +1798,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         date: NaiveDate,
         next_cursor: Option<String>,
     ) -> Result<Page<UserEarningResponse>> {
-        let cursor = next_cursor.map_or(String::new(), |c| format!("&next_cursor={c}"));
+        let cursor = next_cursor.map_or(String::new(), |c| format!("?next_cursor={c}"));
         let request = self
             .client()
             .request(Method::GET, format!("{}rewards/user{cursor}", self.host()))
@@ -1911,7 +1911,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         &self,
         next_cursor: Option<String>,
     ) -> Result<Page<CurrentRewardResponse>> {
-        let cursor = next_cursor.map_or(String::new(), |c| format!("&next_cursor={c}"));
+        let cursor = next_cursor.map_or(String::new(), |c| format!("?next_cursor={c}"));
         let request = self
             .client()
             .request(


### PR DESCRIPTION
Two of the methods are using `&` without `?` in the urls. You can see the GET urls and the problem.

Here are the errors:
`earnings_for_user_for_day`
```
Error: Status: error(405 Method Not Allowed) making GET call to /rewards/user&next_cursor=LTE= with

Caused by:
    error(405 Method Not Allowed) making GET call to /rewards/user&next_cursor=LTE= with
```

`current_rewards`
```
Error: Status: error(400 Bad Request) making GET call to /rewards/markets/current&next_cursor=NTAw with {"error":"Invalid market"}


Caused by:
    error(400 Bad Request) making GET call to /rewards/markets/current&next_cursor=NTAw with {"error":"Invalid market"}
```