### PR TITLE
fix(clob): serialize PriceHistoryRequest market as decimal token_id

### DIFF
--- a/src/clob/types/request.rs
+++ b/src/clob/types/request.rs
@@ -69,13 +69,15 @@ pub struct LastTradePriceRequest {
     pub token_id: U256,
 }
 
+#[serde_as]
 #[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Builder)]
 #[builder(on(String, into))]
 pub struct PriceHistoryRequest {
-    /// The market condition ID.
-    pub market: B256,
+    /// The CLOB token ID to fetch price history for.
+    #[serde_as(as = "DisplayFromStr")]
+    pub market: U256,
     /// The time range for the price history query.
     /// Either a predefined interval or explicit start/end timestamps.
     #[serde(flatten)]

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -243,14 +243,11 @@ mod unauthenticated {
         let server = MockServer::start();
         let client = Client::new(&server.base_url(), Config::default())?;
 
-        let test_market = b256!("0000000000000000000000000000000000000000000000000000000000000123");
+        let test_market = U256::from(0x123);
         let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/prices-history")
-                .query_param(
-                    "market",
-                    "0x0000000000000000000000000000000000000000000000000000000000000123",
-                )
+                .query_param("market", "291")
                 .query_param("interval", "1h")
                 .query_param("fidelity", "10");
             then.status(StatusCode::OK).json_body(json!({
@@ -288,14 +285,11 @@ mod unauthenticated {
         let server = MockServer::start();
         let client = Client::new(&server.base_url(), Config::default())?;
 
-        let test_market = b256!("0000000000000000000000000000000000000000000000000000000000000123");
+        let test_market = U256::from(0x123);
         let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/prices-history")
-                .query_param(
-                    "market",
-                    "0x0000000000000000000000000000000000000000000000000000000000000123",
-                )
+                .query_param("market", "291")
                 .query_param("startTs", "1000")
                 .query_param("endTs", "2000");
             then.status(StatusCode::OK).json_body(json!({


### PR DESCRIPTION
  ## Summary                                                                                                                        

[Fixes Polymarket/rs-clob-client#223]: The `/prices-history` endpoint expects a decimal token_id string, not a hex-encoded condition_id                                                                                                                                                                    

 ## Changes
  - Change `PriceHistoryRequest.market` from `B256` to `U256` with `DisplayFromStr` serialization                                   
  - Updated existing `price_history_with_interval_should_succeed` test to use `U256` and expect decimal format                  
  - Updated existing `price_history_with_range_should_succeed` test to use `U256` and expect decimal format                                                                        
                                                                                                                                                                                                                                                
  ## Tests and Linting                                                                                                                      
                                                                                                                                   
  - [x] All tests pass (`cargo test --all-features`)                                                                                
  - [x] Clippy passes (`cargo clippy --all-features -- -D warnings`)