### PR TITLE
Use token id in price history request

### DIFF
--- a/src/clob/types/request.rs
+++ b/src/clob/types/request.rs
@@ -70,12 +70,14 @@ pub struct LastTradePriceRequest {
 }
 
 #[non_exhaustive]
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Builder)]
 #[builder(on(String, into))]
 pub struct PriceHistoryRequest {
-    /// The market condition ID.
-    pub market: B256,
+    /// The CLOB token ID.
+    #[serde_as(as = "DisplayFromStr")]
+    pub market: U256,
     /// The time range for the price history query.
     /// Either a predefined interval or explicit start/end timestamps.
     #[serde(flatten)]

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -243,14 +243,11 @@ mod unauthenticated {
         let server = MockServer::start();
         let client = Client::new(&server.base_url(), Config::default())?;
 
-        let test_market = b256!("0000000000000000000000000000000000000000000000000000000000000123");
+        let test_market = U256::from(123);
         let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/prices-history")
-                .query_param(
-                    "market",
-                    "0x0000000000000000000000000000000000000000000000000000000000000123",
-                )
+                .query_param("market", "123")
                 .query_param("interval", "1h")
                 .query_param("fidelity", "10");
             then.status(StatusCode::OK).json_body(json!({
@@ -288,14 +285,11 @@ mod unauthenticated {
         let server = MockServer::start();
         let client = Client::new(&server.base_url(), Config::default())?;
 
-        let test_market = b256!("0000000000000000000000000000000000000000000000000000000000000123");
+        let test_market = U256::from(291);
         let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/prices-history")
-                .query_param(
-                    "market",
-                    "0x0000000000000000000000000000000000000000000000000000000000000123",
-                )
+                .query_param("market", "291")
                 .query_param("startTs", "1000")
                 .query_param("endTs", "2000");
             then.status(StatusCode::OK).json_body(json!({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the wire format for the `market` query param on `price_history`, which can break callers or requests if the backend still expects a condition id.
> 
> **Overview**
> Updates `PriceHistoryRequest` so `market` is now a CLOB token id (`U256`, serialized via `DisplayFromStr`) instead of a condition id (`B256`), changing the `/prices-history` query string from `0x…` to a plain numeric value.
> 
> Adjusts `tests/clob.rs` mocks and request construction to match the new `market` serialization for both interval-based and explicit range price history queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19b89026daf3e622d1a5bdd9ec3f58341b02c318. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->