### PR TITLE
feat(ctf): add support for proxy wallet when calling CTF contract

### DIFF
--- a/examples/ctf.rs
+++ b/examples/ctf.rs
@@ -33,13 +33,25 @@ use anyhow::Result;
 use polymarket_client_sdk::ctf::Client;
 use polymarket_client_sdk::ctf::types::{
     CollectionIdRequest, ConditionIdRequest, MergePositionsRequest, PositionIdRequest,
-    RedeemPositionsRequest, SplitPositionRequest,
+    RedeemPositionsRequest, SplitPositionRequest, WalletType,
 };
 use polymarket_client_sdk::types::address;
 use polymarket_client_sdk::{POLYGON, PRIVATE_KEY_VAR};
 use tracing::{error, info};
 
 const RPC_URL: &str = "https://polygon-rpc.com";
+
+#[expect(
+    clippy::ptr_arg,
+    reason = "Only used in .find_map and doesn't compile with &str"
+)]
+fn parse_wallet_type(arg: &String) -> Option<WalletType> {
+    match arg.as_str() {
+        "eoa" | "EOA" => Some(WalletType::EOA),
+        "proxy" | "PROXY" | "Proxy" => Some(WalletType::Proxy),
+        _ => None,
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -136,12 +148,23 @@ async fn main() -> Result<()> {
             env::var(PRIVATE_KEY_VAR).expect("Need a private key for write operations");
         let signer = LocalSigner::from_str(&private_key)?.with_chain_id(Some(chain));
 
+        // For wallet types other than EOA, we need to provide the wallet type, currently
+        // only EOA and PROXY are supported. Only required for write operations.
+        let wallet_type = args.iter().find_map(parse_wallet_type);
+
         let provider = ProviderBuilder::new()
             .wallet(signer.clone())
             .connect(RPC_URL)
             .await?;
 
-        let client = Client::new(provider, chain)?;
+        let client = if let Some(wallet_type) = wallet_type {
+            // Provide the wallet type so the CTF client can properly handle calls for wallet
+            // types other than EOA (Externally Owned Account)
+            Client::new(provider, chain)?.with_wallet_type(wallet_type)
+        } else {
+            // Use default (EOA) behaviour if no wallet type is provided
+            Client::new(provider, chain)?
+        };
         let wallet_address = signer.address();
 
         info!("Using wallet: {wallet_address:?}");

--- a/src/ctf/client.rs
+++ b/src/ctf/client.rs
@@ -31,18 +31,23 @@
     reason = "Alloy sol! macro generates code that triggers these lints"
 )]
 
-use alloy::primitives::ChainId;
-use alloy::providers::Provider;
+use std::marker::PhantomData;
+
+use alloy::contract::CallBuilder;
+use alloy::network::Ethereum;
+use alloy::primitives::{ChainId, U256};
+use alloy::providers::{MulticallItem as _, PendingTransactionBuilder, Provider};
 use alloy::sol;
+use alloy::sol_types::SolCall;
 
 use super::error::CtfError;
 use super::types::{
     CollectionIdRequest, CollectionIdResponse, ConditionIdRequest, ConditionIdResponse,
     MergePositionsRequest, MergePositionsResponse, PositionIdRequest, PositionIdResponse,
     RedeemNegRiskRequest, RedeemNegRiskResponse, RedeemPositionsRequest, RedeemPositionsResponse,
-    SplitPositionRequest, SplitPositionResponse,
+    SplitPositionRequest, SplitPositionResponse, WalletType,
 };
-use crate::{Result, contract_config};
+use crate::{Result, contract_config, wallet_contract_config};
 
 // CTF (Conditional Token Framework) contract interface
 //
@@ -122,6 +127,27 @@ sol! {
             uint256[] calldata amounts
         ) external;
     }
+
+    #[sol(rpc)]
+    interface IProxyFactory {
+        /// Routes a CTF contract call through the proxy contract
+        function proxy(ProxyCall[] memory calls) public payable returns (bytes[] memory returnValues);
+    }
+
+    /// Type of call passed to proxy contract
+    enum CallType {
+        INVALID,
+        CALL,
+        DELEGATECALL
+    }
+
+    /// Represents a CTF contract call routed via the proxy contract
+    struct ProxyCall {
+        CallType typeCode;
+        address payable to;
+        uint256 value;
+        bytes data;
+    }
 }
 
 /// Client for interacting with the Conditional Token Framework contract.
@@ -132,7 +158,9 @@ sol! {
 pub struct Client<P: Provider> {
     contract: IConditionalTokens::IConditionalTokensInstance<P>,
     neg_risk_adapter: Option<INegRiskAdapter::INegRiskAdapterInstance<P>>,
+    proxy_factory: Option<IProxyFactory::IProxyFactoryInstance<P>>,
     provider: P,
+    wallet_type: WalletType,
 }
 
 impl<P: Provider + Clone> Client<P> {
@@ -152,14 +180,31 @@ impl<P: Provider + Clone> Client<P> {
                 "CTF contract configuration not found for chain ID {chain_id}"
             ))
         })?;
+        let wallet_contract_config = wallet_contract_config(chain_id);
 
         let contract = IConditionalTokens::new(config.conditional_tokens, provider.clone());
+        let proxy_factory = wallet_contract_config.and_then(|cfg| {
+            cfg.proxy_factory
+                .map(|address| IProxyFactory::new(address, provider.clone()))
+        });
 
         Ok(Self {
             contract,
             neg_risk_adapter: None,
+            proxy_factory,
             provider,
+            wallet_type: WalletType::default(),
         })
+    }
+
+    /// Use a different [`WalleType`] to the default type (EOA).
+    ///
+    /// Different wallet types use different methods to execute functions
+    /// on the CTF contract.
+    #[must_use = "Returns client, doesn't modify in place"]
+    pub fn with_wallet_type(mut self, wallet_type: WalletType) -> Self {
+        self.wallet_type = wallet_type;
+        self
     }
 
     /// Creates a new CTF client with `NegRisk` adapter support.
@@ -181,17 +226,24 @@ impl<P: Provider + Clone> Client<P> {
                 "NegRisk contract configuration not found for chain ID {chain_id}"
             ))
         })?;
+        let wallet_contract_config = wallet_contract_config(chain_id);
 
         let contract = IConditionalTokens::new(config.conditional_tokens, provider.clone());
 
         let neg_risk_adapter = config
             .neg_risk_adapter
             .map(|addr| INegRiskAdapter::new(addr, provider.clone()));
+        let proxy_factory = wallet_contract_config.and_then(|cfg| {
+            cfg.proxy_factory
+                .map(|address| IProxyFactory::new(address, provider.clone()))
+        });
 
         Ok(Self {
             contract,
             neg_risk_adapter,
+            proxy_factory,
             provider,
+            wallet_type: WalletType::default(),
         })
     }
 
@@ -306,20 +358,16 @@ impl<P: Provider + Clone> Client<P> {
         &self,
         request: &SplitPositionRequest,
     ) -> Result<SplitPositionResponse> {
-        let pending_tx = self
-            .contract
-            .splitPosition(
-                request.collateral_token,
-                request.parent_collection_id,
-                request.condition_id,
-                request.partition.clone(),
-                request.amount,
-            )
-            .send()
-            .await
-            .map_err(|e| {
-                CtfError::ContractCall(format!("Failed to send split transaction: {e}"))
-            })?;
+        let call = self.contract.splitPosition(
+            request.collateral_token,
+            request.parent_collection_id,
+            request.condition_id,
+            request.partition.clone(),
+            request.amount,
+        );
+        let pending_tx = self.send_call(call).await.map_err(|e| {
+            CtfError::ContractCall(format!("Failed to send split transaction: {e}"))
+        })?;
 
         let transaction_hash = *pending_tx.tx_hash();
 
@@ -358,20 +406,16 @@ impl<P: Provider + Clone> Client<P> {
         &self,
         request: &MergePositionsRequest,
     ) -> Result<MergePositionsResponse> {
-        let pending_tx = self
-            .contract
-            .mergePositions(
-                request.collateral_token,
-                request.parent_collection_id,
-                request.condition_id,
-                request.partition.clone(),
-                request.amount,
-            )
-            .send()
-            .await
-            .map_err(|e| {
-                CtfError::ContractCall(format!("Failed to send merge transaction: {e}"))
-            })?;
+        let call = self.contract.mergePositions(
+            request.collateral_token,
+            request.parent_collection_id,
+            request.condition_id,
+            request.partition.clone(),
+            request.amount,
+        );
+        let pending_tx = self.send_call(call).await.map_err(|e| {
+            CtfError::ContractCall(format!("Failed to send merge transaction: {e}"))
+        })?;
 
         let transaction_hash = *pending_tx.tx_hash();
 
@@ -410,19 +454,15 @@ impl<P: Provider + Clone> Client<P> {
         &self,
         request: &RedeemPositionsRequest,
     ) -> Result<RedeemPositionsResponse> {
-        let pending_tx = self
-            .contract
-            .redeemPositions(
-                request.collateral_token,
-                request.parent_collection_id,
-                request.condition_id,
-                request.index_sets.clone(),
-            )
-            .send()
-            .await
-            .map_err(|e| {
-                CtfError::ContractCall(format!("Failed to send redeem transaction: {e}"))
-            })?;
+        let call = self.contract.redeemPositions(
+            request.collateral_token,
+            request.parent_collection_id,
+            request.condition_id,
+            request.index_sets.clone(),
+        );
+        let pending_tx = self.send_call(call).await.map_err(|e| {
+            CtfError::ContractCall(format!("Failed to send redeem transaction: {e}"))
+        })?;
 
         let transaction_hash = *pending_tx.tx_hash();
 
@@ -470,13 +510,10 @@ impl<P: Provider + Clone> Client<P> {
             )
         })?;
 
-        let pending_tx = adapter
-            .redeemPositions(request.condition_id, request.amounts.clone())
-            .send()
-            .await
-            .map_err(|e| {
-                CtfError::ContractCall(format!("Failed to send NegRisk redeem transaction: {e}"))
-            })?;
+        let call = adapter.redeemPositions(request.condition_id, request.amounts.clone());
+        let pending_tx = self.send_call(call).await.map_err(|e| {
+            CtfError::ContractCall(format!("Failed to send NegRisk redeem transaction: {e}"))
+        })?;
 
         let transaction_hash = *pending_tx.tx_hash();
 
@@ -496,5 +533,37 @@ impl<P: Provider + Clone> Client<P> {
     #[must_use]
     pub const fn provider(&self) -> &P {
         &self.provider
+    }
+
+    /// Sends call via method corresponding to `WalletType`. Only required for
+    /// write functions.
+    #[inline]
+    async fn send_call<Pr, D>(
+        &self,
+        call: CallBuilder<Pr, PhantomData<D>, Ethereum>,
+    ) -> alloy::contract::Result<PendingTransactionBuilder<Ethereum>, String>
+    where
+        D: SolCall,
+        Pr: Provider<Ethereum>,
+    {
+        match self.wallet_type {
+            WalletType::EOA => call.send().await.map_err(|e| e.to_string()),
+            WalletType::Proxy => {
+                let proxy_transaction = ProxyCall {
+                    typeCode: CallType::CALL,
+                    to: call.target(),
+                    value: U256::from(0),
+                    data: call.calldata().clone(),
+                };
+                let proxy_contract = self.proxy_factory.as_ref().ok_or_else(|| {
+                    "ProxyFactory contract does not exist on this chain".to_owned()
+                })?;
+                proxy_contract
+                    .proxy(vec![proxy_transaction])
+                    .send()
+                    .await
+                    .map_err(|e| e.to_string())
+            }
+        }
     }
 }

--- a/src/ctf/types/mod.rs
+++ b/src/ctf/types/mod.rs
@@ -11,3 +11,35 @@ pub use response::{
     CollectionIdResponse, ConditionIdResponse, MergePositionsResponse, PositionIdResponse,
     RedeemNegRiskResponse, RedeemPositionsResponse, SplitPositionResponse,
 };
+use serde::{Deserialize, Serialize};
+
+/// The wallet type being used to interact with the CTF contract, which determines
+/// the method of calling write functions on the contract.
+///
+/// - **Externally Owned Accounts** (EOA) call the CTF contract directly and pay
+///   gas fees directly. This is the default behaviour and should be used when
+///   using your own wallet (e.g. metamask)
+/// - **Proxy wallets** call the CTF contract via the `ProxyFactory` contract. Proxy
+///   wallets are generated when signing up to Polymarket with an email or via
+///   google auth etc
+/// - **GNOSIS** safe wallet is currently unimplemented for CTF calls
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum WalletType {
+    /// **Externally Owned Accounts** (EOA) call the CTF contract directly and pay
+    /// gas fees directly. This is the default behaviour and should be used when
+    /// using your own wallet (e.g. metamask)
+    #[default]
+    #[serde(alias = "Eoa")]
+    #[serde(alias = "eoa")]
+    EOA,
+    /// **Proxy wallets** call the CTF contract via the `ProxyFactory` contract. Proxy
+    /// wallets are generated when signing up to Polymarket with an email or via
+    /// google auth etc
+    #[serde(alias = "Proxy")]
+    #[serde(alias = "proxy")]
+    Proxy,
+    // TODO: GNOSIS safe wallet
+    // GnosisSafe,
+}


### PR DESCRIPTION
# Problem

CTF client can currently only perform write operations (split/merge/redeem) for EOA type wallets. Read operations work for all types. 

# Solution

I added a `wallet_type` field to the CTF client (defaults to `EOA` so default behaviour isn't changed if user doesn't set it). 

The `send_call()` method takes a call to the CTF contract and uses the appropriate mechanism to send the tx based on wallet type. `send_call()` is only used for split/merge/redeem. 

For EOA type it doesn't do anything differently.

The reason I created a separate `WalletType` enum instead of using the existing `SignatureType` enum is because `GNOSIS` isn't yet implemented, and I wanted to limit the variants to types that are actually implemented. If GNOSIS is eventually implemented, then you can just re-use the signature type enum. 

Also derived `Deserialize` on the enum so users can include it in their own configs etc (same for `Serialize` in case people want to be able to `Serialize` their own configs to another format or something). 

## Example usage

For EOA wallets, CTF initialisation is the same:

```rust
// Using with default (EOA) wallet type
let ctf = CtfClient::new(provider, ContractClient::CHAIN)?;
ctf.split_position(...).await?;
```

For proxy wallets, just one extra method is required when initialising the client:
```rust
// Using with proxy wallet type
let ctf = CtfClient::new(provider, ContractClient::CHAIN)?
    .with_wallet_type(WalletType::Proxy);
ctf.split_position(...).await?;
```

Added example usage to `examples/ctf.rs`.

# Risk

Existing behaviour isn't changed. CTF client uses EOA by default, which makes contract calls in exactly the same way as before. 

I've been using this implementation myself to do all 3 types of write calls (split, merge and redeem) with a proxy wallet and had no issues. Beforehand I couldn't make those calls using the CTF client with a proxy wallet. 

---

fixes #277


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CTF write transactions are constructed/sent (direct vs proxy-routed), which can impact on-chain execution and failure modes across supported chains, though default EOA behavior remains unchanged.
> 
> **Overview**
> Adds **proxy wallet support** for CTF write operations by introducing a new `WalletType` (defaulting to `EOA`) and routing write calls through `ProxyFactory` when `Proxy` is selected.
> 
> CTF write methods (`split_position`, `merge_positions`, `redeem_positions`, `redeem_neg_risk`) now share a `send_call` helper that either sends the transaction directly (EOA) or wraps the calldata into a `ProxyCall` and submits it via the configured `IProxyFactory` contract; the `ctf` example is updated to accept a wallet type argument and construct the client with `with_wallet_type` for write mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd197534ce9a43270e745f041ec087aaf53ef8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->