### PR TITLE
fix: Config::default() zero heartbeat_interval

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -358,7 +358,7 @@ impl Default for Client<Unauthenticated> {
 }
 
 /// Configuration for [`Client`]
-#[derive(Clone, Debug, Default, Builder)]
+#[derive(Clone, Debug, Builder)]
 pub struct Config {
     /// Whether the [`Client`] will use the server time provided by Polymarket when creating auth
     /// headers. This adds another round trip to the requests.
@@ -372,6 +372,17 @@ pub struct Config {
     #[builder(default = Duration::from_secs(5))]
     /// How often the [`Client`] will automatically submit heartbeats. The default is five (5) seconds.
     heartbeat_interval: Duration,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            use_server_time: false,
+            geoblock_host: None,
+            #[cfg(feature = "heartbeats")]
+            heartbeat_interval: Duration::from_secs(5),
+        }
+    }
 }
 
 /// The default geoblock API host (separate from CLOB host)


### PR DESCRIPTION
## Summary

- `Config` derived both `Default` and `bon::Builder`, but their defaults diverged: the builder set `heartbeat_interval` to 5 seconds while `derive(Default)` produced `Duration::ZERO`, which panics at runtime in `tokio::time::interval`.
- Replace `derive(Default)` with a manual `impl Default` that matches the builder defaults, consistent with the pattern already used in `ws::Config`.

Closes #289

## Test plan

- [x] `cargo build --all-features` passes
- [x] `cargo test --all-features` passes (49 passed, 0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes with zero warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only `Config::default()` initialization to prevent a zero-duration heartbeat interval that could panic when the `heartbeats` feature is enabled.
> 
> **Overview**
> Fixes a mismatch between `bon::Builder` defaults and `derive(Default)` for `clob::client::Config`.
> 
> `Config` no longer derives `Default`; it now has a manual `impl Default` that sets `heartbeat_interval` to 5 seconds (and keeps other fields at their intended defaults), avoiding runtime failures from a zero-duration interval when automatic heartbeats are used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf2be7eca8faf875577716e0647df6db2805c8b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->