### PR TITLE
docs: cleanup clob docs/commands

### DIFF
--- a/examples/clob/heartbeats.rs
+++ b/examples/clob/heartbeats.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with:
 //! ```sh
-//! RUST_LOG=debug,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example heartbeats --features heartbeats,tracing
+//! RUST_LOG=debug,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example heartbeats --features heartbeats,tracing,clob
 //! ```
 //!
 use std::str::FromStr as _;

--- a/examples/clob/streaming.rs
+++ b/examples/clob/streaming.rs
@@ -6,17 +6,17 @@
 //!
 //! Run with tracing enabled:
 //! ```sh
-//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example streaming --features tracing
+//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example streaming --features tracing,clob
 //! ```
 //!
 //! Optionally log to a file:
 //! ```sh
-//! LOG_FILE=streaming.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example streaming --features tracing
+//! LOG_FILE=streaming.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example streaming --features tracing,clob
 //! ```
 //!
 //! For authenticated streaming, set the `POLYMARKET_PRIVATE_KEY` environment variable:
 //! ```sh
-//! POLYMARKET_PRIVATE_KEY=0x... RUST_LOG=info cargo run --example streaming --features tracing
+//! POLYMARKET_PRIVATE_KEY=0x... RUST_LOG=info cargo run --example streaming --features tracing,clob
 //! ```
 
 use std::fs::File;

--- a/examples/clob/unauthenticated.rs
+++ b/examples/clob/unauthenticated.rs
@@ -6,12 +6,12 @@
 //!
 //! Run with tracing enabled:
 //! ```sh
-//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example unauthenticated --features tracing
+//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example unauthenticated --features tracing,clob
 //! ```
 //!
 //! Optionally log to a file:
 //! ```sh
-//! LOG_FILE=clob.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example unauthenticated --features tracing
+//! LOG_FILE=clob.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example unauthenticated --features tracing,clob
 //! ```
 
 use std::collections::HashMap;

--- a/examples/clob/ws/orderbook.rs
+++ b/examples/clob/ws/orderbook.rs
@@ -7,12 +7,12 @@
 //!
 //! Run with tracing enabled:
 //! ```sh
-//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_orderbook --features ws,tracing
+//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_orderbook --features ws,tracing,clob
 //! ```
 //!
 //! Optionally log to a file:
 //! ```sh
-//! LOG_FILE=websocket_orderbook.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_orderbook --features ws,tracing
+//! LOG_FILE=websocket_orderbook.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_orderbook --features ws,tracing,clob
 //! ```
 
 use std::fs::File;

--- a/examples/clob/ws/unsubscribe.rs
+++ b/examples/clob/ws/unsubscribe.rs
@@ -7,17 +7,17 @@
 //!
 //! Run with tracing enabled:
 //! ```sh
-//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_unsubscribe --features ws,tracing
+//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_unsubscribe --features ws,tracing,clob
 //! ```
 //!
 //! Optionally log to a file:
 //! ```sh
-//! LOG_FILE=websocket_unsubscribe.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_unsubscribe --features ws,tracing
+//! LOG_FILE=websocket_unsubscribe.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_unsubscribe --features ws,tracing,clob
 //! ```
 //!
 //! With debug level, you can see subscribe/unsubscribe wire messages:
 //! ```sh
-//! RUST_LOG=debug,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_unsubscribe --features ws,tracing
+//! RUST_LOG=debug,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_unsubscribe --features ws,tracing,clob
 //! ```
 
 use std::fs::File;

--- a/examples/clob/ws/user.rs
+++ b/examples/clob/ws/user.rs
@@ -7,12 +7,12 @@
 //!
 //! Run with tracing enabled:
 //! ```sh
-//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_user --features ws,tracing
+//! RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_user --features ws,tracing,clob
 //! ```
 //!
 //! Optionally log to a file:
 //! ```sh
-//! LOG_FILE=websocket_user.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_user --features ws,tracing
+//! LOG_FILE=websocket_user.log RUST_LOG=info,hyper_util=off,hyper=off,reqwest=off,h2=off,rustls=off cargo run --example websocket_user --features ws,tracing,clob
 //! ```
 //!
 //! Requires the following environment variables:

--- a/src/clob/mod.rs
+++ b/src/clob/mod.rs
@@ -1,6 +1,6 @@
 //! Polymarket CLOB (Central Limit Order Book) API client and types.
 //!
-//! **Feature flag:** None (this is the core module, always available)
+//! **Feature flag:** `clob` (required to use this module)
 //!
 //! This module provides the primary client for interacting with the Polymarket CLOB API,
 //! which handles all trading operations including order placement, cancellation, market
@@ -135,9 +135,6 @@
 //! # Optional Features
 //!
 //! - **`ws`**: Enables WebSocket support for real-time orderbook and trade streams
-//! - **`heartbeats`**: Enables automatic heartbeat mechanism for authenticated sessions
-//! - **`tracing`**: Enables detailed request/response tracing
-//! - **`rfq`**: Enables RFQ (Request for Quote) endpoints for institutional trading
 //!
 //! # API Base URL
 //!


### PR DESCRIPTION
Add clob feature flag to example run commands, and update docs to reflect that it's behind a feature flag now. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that update example run commands and module docs to match feature gating; no runtime logic is modified.
> 
> **Overview**
> Updates all CLOB examples’ `cargo run` commands to include the `clob` feature (including WS and heartbeats variants) so they match the examples’ `required-features`.
> 
> Adjusts `src/clob/mod.rs` docs to state the module is behind the `clob` feature flag and trims the optional-features list accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1895bb3f33d37739e9dfaa6223711f66b4f245d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->