### PR TITLE
fix: BuilderTradeResponse deserialization bugs (#293, #294)

### DIFF
--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -653,13 +653,11 @@ pub struct BuilderTradeResponse {
     pub trade_type: String,
     /// Hash of the taker order (optional — may be empty for pending trades).
     #[serde(default)]
-    #[builder(default)]
     pub taker_order_hash: Option<B256>,
     /// Builder API key ID (UUID, not an Ethereum address).
     pub builder: ApiKey,
     /// The market condition ID (optional — may be empty in some API responses).
     #[serde(default)]
-    #[builder(default)]
     pub market: Option<B256>,
     pub asset_id: U256,
     pub side: Side,
@@ -674,7 +672,6 @@ pub struct BuilderTradeResponse {
     pub maker: Address,
     /// On-chain transaction hash (optional — empty for unfilled/pending trades).
     #[serde(default)]
-    #[builder(default)]
     pub transaction_hash: Option<B256>,
     #[serde_as(as = "TimestampSeconds<String>")]
     pub match_time: DateTime<Utc>,


### PR DESCRIPTION
## Summary

Fixes two deserialization bugs in `BuilderTradeResponse`:

- **`builder` field** (`Address` → `ApiKey`): The `/builder/trades` API returns a UUID builder key ID (e.g. `"019b618b-4a91-7dd9-a4c9-aadfbcbd5b95"`), not an Ethereum address. Deserialization fails with `invalid string length`. The TypeScript SDK correctly types this as `string`. **Fixes #294.**

- **`B256` fields** (`taker_order_hash`, `market`, `transaction_hash` → `Option<B256>`): The API can return empty strings for pending/unfilled trades. Added `#[serde(default)]` + `#[builder(default)]` to handle gracefully. **Fixes #293.**

## Changes

- `src/clob/types/response.rs`: `builder: Address` → `builder: ApiKey`, three `B256` fields → `Option<B256>`

## Verified

Tested against live `/builder/trades` API responses. Both issues confirmed reproducible with actual API JSON.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes public response types (`builder` and several hash fields) and may require downstream code updates, though the changes are narrowly scoped to deserialization behavior.
> 
> **Overview**
> Updates `BuilderTradeResponse` deserialization to match real `/builder/trades` responses. The `builder` field is retyped from an Ethereum `Address` to an `ApiKey` (UUID), and `taker_order_hash`, `market`, and `transaction_hash` are made optional with `#[serde(default)]` to gracefully handle empty strings for pending/unfilled trades.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c6a9cdd15c1f93748d8474a2c9e910bd3416e7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->