### PR TITLE
chore: release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/Polymarket/rs-clob-client/compare/v0.4.4...v0.4.5) - 2026-05-11
+
+### Fixed
+
+- *(ws)* parse RETRYING and FAILED trade statuses ([#300](https://github.com/Polymarket/rs-clob-client/pull/300))
+- Config::default() zero heartbeat_interval ([#290](https://github.com/Polymarket/rs-clob-client/pull/290))
+
+### Other
+
+- add archive notice and link to V2 client ([#348](https://github.com/Polymarket/rs-clob-client/pull/348))
+- *(cargo)* bump rust_decimal from 1.40.0 to 1.41.0 ([#314](https://github.com/Polymarket/rs-clob-client/pull/314))
+- *(cargo)* bump uuid from 1.22.0 to 1.23.0 ([#312](https://github.com/Polymarket/rs-clob-client/pull/312))
+- *(gha)* bump dtolnay/rust-toolchain from efa25f7f19611383d5b0ccf2d1c8914531636bf9 to 3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 ([#310](https://github.com/Polymarket/rs-clob-client/pull/310))
+- *(gha)* bump codecov/codecov-action from 5 to 6 ([#309](https://github.com/Polymarket/rs-clob-client/pull/309))
+- *(cargo)* bump tokio-tungstenite from 0.28.0 to 0.29.0 ([#302](https://github.com/Polymarket/rs-clob-client/pull/302))
+- *(gha)* bump ytanikin/pr-conventional-commits from 1.5.1 to 1.5.2 ([#301](https://github.com/Polymarket/rs-clob-client/pull/301))
+
 ## [0.4.4](https://github.com/Polymarket/rs-clob-client/compare/v0.4.3...v0.4.4) - 2026-03-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "polymarket-client-sdk"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polymarket-client-sdk"
 description = "Polymarket CLOB (Central Limit Order Book) API client SDK"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
     "Polymarket Engineering <engineering@polymarket.com>",
     "Chaz Byrnes <chaz@polymarket.com>",


### PR DESCRIPTION



## 🤖 New release

* `polymarket-client-sdk`: 0.4.4 -> 0.4.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.5](https://github.com/Polymarket/rs-clob-client/compare/v0.4.4...v0.4.5) - 2026-05-11

### Fixed

- *(ws)* parse RETRYING and FAILED trade statuses ([#300](https://github.com/Polymarket/rs-clob-client/pull/300))
- Config::default() zero heartbeat_interval ([#290](https://github.com/Polymarket/rs-clob-client/pull/290))

### Other

- add archive notice and link to V2 client ([#348](https://github.com/Polymarket/rs-clob-client/pull/348))
- *(cargo)* bump rust_decimal from 1.40.0 to 1.41.0 ([#314](https://github.com/Polymarket/rs-clob-client/pull/314))
- *(cargo)* bump uuid from 1.22.0 to 1.23.0 ([#312](https://github.com/Polymarket/rs-clob-client/pull/312))
- *(gha)* bump dtolnay/rust-toolchain from efa25f7f19611383d5b0ccf2d1c8914531636bf9 to 3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 ([#310](https://github.com/Polymarket/rs-clob-client/pull/310))
- *(gha)* bump codecov/codecov-action from 5 to 6 ([#309](https://github.com/Polymarket/rs-clob-client/pull/309))
- *(cargo)* bump tokio-tungstenite from 0.28.0 to 0.29.0 ([#302](https://github.com/Polymarket/rs-clob-client/pull/302))
- *(gha)* bump ytanikin/pr-conventional-commits from 1.5.1 to 1.5.2 ([#301](https://github.com/Polymarket/rs-clob-client/pull/301))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: bumps crate version to `0.4.5` and updates `CHANGELOG.md`, with no functional code changes in this diff.
> 
> **Overview**
> Cuts release `v0.4.5` by bumping the crate version in `Cargo.toml`/`Cargo.lock` and adding the `0.4.5` entry to `CHANGELOG.md` (documenting recent fixes and dependency/GHA bumps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f381938dd6e34f93817cf35319e035959d452d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->