### PR TITLE
fix: downgrade expected API error log from warn to debug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ async fn request<Response: DeserializeOwned>(
         let message = response.text().await.unwrap_or_default();
 
         #[cfg(feature = "tracing")]
-        tracing::warn!(
+        tracing::debug!(
             status = %status_code,
             method = %method,
             path = %path,


### PR DESCRIPTION
The generic `request()` handler in `lib.rs` logs a WARN for every non-2xx response. This includes expected 400s during `create_or_derive_api_key` when a key already exists and the client falls back to `derive_api_key`.

Users see a scary warning even though auth succeeds normally. This changes the log level to `debug` so it's still available for troubleshooting but doesn't trigger false alarms.

Closes #260

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `tracing` log level emitted on non-success HTTP responses, without altering request/response handling or error propagation.
> 
> **Overview**
> Downgrades the generic `request()` handler’s log for non-2xx HTTP responses from `warn!` to `debug!` (under the `tracing` feature), reducing noisy/expected warning logs while keeping the error details available for troubleshooting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b027ef79a13fb46cdb12bc08ef9c67b0d885b0f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->