### PR TITLE
fix(data): preserve unknown activity side values

### DIFF
--- a/src/data/types/response.rs
+++ b/src/data/types/response.rs
@@ -19,11 +19,15 @@ where
     match opt {
         None => Ok(None),
         Some(s) if s.is_empty() => Ok(None),
-        Some(s) => match s.to_uppercase().as_str() {
-            "BUY" => Ok(Some(Side::Buy)),
-            "SELL" => Ok(Some(Side::Sell)),
-            _ => Ok(None),
-        },
+        Some(s) => {
+            let side = match s.to_uppercase().as_str() {
+                "BUY" => Side::Buy,
+                "SELL" => Side::Sell,
+                _ => Side::Unknown(s),
+            };
+
+            Ok(Some(side))
+        }
     }
 }
 

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -258,6 +258,76 @@ mod activity {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn activity_unknown_side_should_be_preserved() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = Client::new(&server.base_url())?;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/activity")
+                .query_param("user", "0x1234567890abcdef1234567890abcdef12345678");
+            then.status(StatusCode::OK).json_body(json!([
+                {
+                    "proxyWallet": "0x1234567890abcdef1234567890abcdef12345678",
+                    "timestamp": 1_703_980_800,
+                    "conditionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                    "type": "TRADE",
+                    "size": 100.0,
+                    "usdcSize": 55.0,
+                    "transactionHash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+                    "price": 0.55,
+                    "asset": "0x1111111111111111111111111111111111111111111111111111111111111111",
+                    "side": "SIDEWAYS"
+                }
+            ]));
+        });
+
+        let request = ActivityRequest::builder().user(test_user()).build();
+        let response = client.activity(&request).await?;
+
+        assert_eq!(response.len(), 1);
+        assert_eq!(response[0].side, Some(Side::Unknown("SIDEWAYS".to_owned())));
+        mock.assert();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn activity_empty_side_should_still_be_none() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = Client::new(&server.base_url())?;
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/activity")
+                .query_param("user", "0x1234567890abcdef1234567890abcdef12345678");
+            then.status(StatusCode::OK).json_body(json!([
+                {
+                    "proxyWallet": "0x1234567890abcdef1234567890abcdef12345678",
+                    "timestamp": 1_703_980_800,
+                    "conditionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                    "type": "TRADE",
+                    "size": 100.0,
+                    "usdcSize": 55.0,
+                    "transactionHash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+                    "price": 0.55,
+                    "asset": "0x1111111111111111111111111111111111111111111111111111111111111111",
+                    "side": ""
+                }
+            ]));
+        });
+
+        let request = ActivityRequest::builder().user(test_user()).build();
+        let response = client.activity(&request).await?;
+
+        assert_eq!(response.len(), 1);
+        assert_eq!(response[0].side, None);
+        mock.assert();
+
+        Ok(())
+    }
 }
 
 mod holders {


### PR DESCRIPTION
## Summary

Preserve unknown `Activity.side` values instead of dropping them during Data API deserialization.

## Problem

`Activity.side` is deserialized through a custom helper that currently maps:

- `BUY` -> `Some(Side::Buy)`
- `SELL` -> `Some(Side::Sell)`
- empty string -> `None`
- anything else -> `None`

This loses information for forward-compatibility cases, even though `Side` already supports `Unknown(String)`.

As a result, if the API introduces a new non-empty side value, the SDK silently drops it instead of preserving the raw value.

## Fix

Update `deserialize_optional_side` so that:

- `BUY` deserializes to `Some(Side::Buy)`
- `SELL` deserializes to `Some(Side::Sell)`
- empty string still deserializes to `None`
- any other non-empty value deserializes to `Some(Side::Unknown(raw))`

## Tests

Added coverage for:

- preserving an unknown side value
- keeping empty string behavior as `None`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to `Activity.side` deserialization plus tests; behavior only differs for previously-unrecognized non-empty side values.
> 
> **Overview**
> Updates Data API `Activity.side` deserialization to preserve any non-empty, unrecognized side string as `Some(Side::Unknown(raw))` rather than coercing it to `None` (while keeping empty strings as `None`).
> 
> Adds test coverage to ensure unknown side values round-trip into `Side::Unknown` and that empty side strings continue to deserialize to `None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 938b4ba5627e5c97d9315468aae0650b2a9dfe31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->