### PR TITLE
feat(clob): add match_time_nano field to TradeResponse

### DIFF
--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -9,17 +9,17 @@ use bon::Builder;
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{
-    serde_as, DefaultOnError, DefaultOnNull, DisplayFromStr, NoneAsEmptyString,
-    TimestampMilliSeconds, TimestampSeconds, TryFromInto,
+    DefaultOnError, DefaultOnNull, DisplayFromStr, NoneAsEmptyString, TimestampMilliSeconds,
+    TimestampSeconds, TryFromInto, serde_as,
 };
 use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
 
+use crate::Result;
 use crate::auth::ApiKey;
 use crate::clob::types::{OrderStatusType, OrderType, Side, TickSize, TradeStatusType, TraderSide};
 use crate::serde_helpers::StringFromAny;
-use crate::types::{Address, Decimal, B256, U256};
-use crate::Result;
+use crate::types::{Address, B256, Decimal, U256};
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Builder, PartialEq)]


### PR DESCRIPTION
## Summary

- Add `match_time_nano: Option<String>` to `TradeResponse` struct
- Field is documented in the [OpenAPI spec](https://docs.polymarket.com/api-reference/trade/get-trades) but was missing from the Rust struct
- Uses `#[serde(default)]` since the field may not always be present

The CLOB `/trades` endpoint returns `match_time_nano` with nanosecond-precision match timestamps, which is useful for deterministic ordering of trades that share the same second-precision `match_time`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional/deserializable new response field without changing existing parsing behavior, aside from accepting an additional JSON key.
> 
> **Overview**
> Adds `match_time_nano` to `TradeResponse` to capture nanosecond-precision match timestamps (nanoseconds since epoch) returned by the CLOB trades API.
> 
> The field is defaulted for backwards compatibility and deserializes from nullable/string inputs via `serde_with::DisplayFromStr` + `DefaultOnNull`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afd2c277ff47e159906ab51ca1a7c38829ec2c35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->