### PR TITLE
feat(data): add excludeDepositsWithdrawals param to ActivityRequest

### DIFF
--- a/src/data/types/request.rs
+++ b/src/data/types/request.rs
@@ -10,13 +10,13 @@
 
 use bon::Builder;
 use serde::Serialize;
-use serde_with::{formats::CommaSeparator, serde_as, skip_serializing_none, StringWithSeparator};
+use serde_with::{StringWithSeparator, formats::CommaSeparator, serde_as, skip_serializing_none};
 
 use super::{
     ActivitySortBy, ActivityType, BoundedIntError, ClosedPositionSortBy, LeaderboardCategory,
     LeaderboardOrderBy, MarketFilter, PositionSortBy, Side, SortDirection, TimePeriod, TradeFilter,
 };
-use crate::types::{Address, Decimal, B256};
+use crate::types::{Address, B256, Decimal};
 
 /// Validates that an i32 value is within the specified bounds.
 fn validate_bound(


### PR DESCRIPTION
## Summary

- Add `exclude_deposits_withdrawals: Option<bool>` to `ActivityRequest`
- Serialized as `excludeDepositsWithdrawals` to match the data-api parameter name
- The `/activity` endpoint supports this parameter to filter out deposit/withdrawal activities

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional query parameter to `ActivityRequest` with no changes to request execution or response parsing.
> 
> **Overview**
> Adds support for filtering `/activity` results by introducing an optional `exclude_deposits_withdrawals` flag on `ActivityRequest`, serialized as `excludeDepositsWithdrawals` to match the Data API query parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25d81f871b8c36ef312b75122c9f27457a04533a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->