### PR TITLE
perf: skip double deserialization and enable release LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,6 +272,10 @@ unseparated_literal_suffix = "warn"
 unused_trait_names = "warn"
 unwrap_used = "warn"
 
+[profile.release]
+lto = "thin"        # Link-Time Optimization: enables cross-crate inlining
+codegen-units = 1   # Single codegen unit allows more aggressive optimizations
+
 [profile.bench]
 lto = "thin"        # Link-Time Optimization: enables cross-crate inlining
 codegen-units = 1   # Single codegen unit allows more aggressive optimizations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,8 +285,14 @@ async fn request<Response: DeserializeOwned>(
         return Err(Error::status(status_code, method, path, message));
     }
 
-    let json_value = response.json::<serde_json::Value>().await?;
-    let response_data: Option<Response> = serde_helpers::deserialize_with_warnings(json_value)?;
+    #[cfg(feature = "tracing")]
+    let response_data: Option<Response> = {
+        let json_value = response.json::<serde_json::Value>().await?;
+        serde_helpers::deserialize_with_warnings(json_value)?
+    };
+
+    #[cfg(not(feature = "tracing"))]
+    let response_data: Option<Response> = response.json().await?;
 
     if let Some(response) = response_data {
         Ok(response)

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -3,11 +3,14 @@
 //! When the `tracing` feature is enabled, this module also logs warnings for any
 //! unknown fields encountered during deserialization, helping detect API changes.
 
-#[cfg(any(
-    feature = "bridge",
-    feature = "clob",
-    feature = "data",
-    feature = "gamma",
+#[cfg(all(
+    any(feature = "tracing", test),
+    any(
+        feature = "bridge",
+        feature = "clob",
+        feature = "data",
+        feature = "gamma",
+    )
 ))]
 use {serde::de::DeserializeOwned, serde_json::Value};
 
@@ -122,23 +125,19 @@ pub fn deserialize_with_warnings<T: DeserializeOwned>(value: Value) -> crate::Re
         "deserializing JSON"
     );
 
-    // Clone the value so we can look up unknown field values later
-    let original = value.clone();
-
-    // Collect unknown field paths during deserialization
+    let raw_json = value.to_string();
     let mut unknown_paths: Vec<String> = Vec::new();
 
     let result: T = serde_ignored::deserialize(value, |path| {
         unknown_paths.push(path.to_string());
     })
     .inspect_err(|_| {
-        // Re-deserialize with serde_path_to_error to get the error path
-        let json_str = original.to_string();
-        let jd = &mut serde_json::Deserializer::from_str(&json_str);
+        let jd = &mut serde_json::Deserializer::from_str(&raw_json);
         let path_result: Result<T, _> = serde_path_to_error::deserialize(jd);
         if let Err(path_err) = path_result {
             let path = path_err.path().to_string();
             let inner_error = path_err.inner();
+            let original: Value = serde_json::from_str(&raw_json).unwrap_or_default();
             let value_at_path = lookup_value(&original, &path);
             let value_display = format_value(value_at_path);
 
@@ -152,8 +151,8 @@ pub fn deserialize_with_warnings<T: DeserializeOwned>(value: Value) -> crate::Re
         }
     })?;
 
-    // Log warnings for unknown fields with their values
     if !unknown_paths.is_empty() {
+        let original: Value = serde_json::from_str(&raw_json).unwrap_or_default();
         let type_name = type_name::<T>();
         for path in unknown_paths {
             let field_value = lookup_value(&original, &path);
@@ -171,8 +170,8 @@ pub fn deserialize_with_warnings<T: DeserializeOwned>(value: Value) -> crate::Re
     Ok(result)
 }
 
-/// Pass-through deserialization when tracing is disabled.
 #[cfg(all(
+    test,
     not(feature = "tracing"),
     any(
         feature = "bridge",


### PR DESCRIPTION
 ## Summary                                                                                                                                                                  
  - Skip intermediate `serde_json::Value` parsing for HTTP responses when `tracing` is disabled, cutting deserialization work in half for normal production usage
  - Replace deep `Value::clone()` with flat `Value::to_string()` in the tracing deserialization path, reducing many small heap allocations to a single one                    
  - Add `[profile.release]` with `lto = "thin"` and `codegen-units = 1` to match existing bench profile, enabling cross-crate inlining and more aggressive compiler           
  optimizations for release builds      

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the HTTP response deserialization path and `cfg` gating around `serde_helpers`, which could surface subtle differences in how optional/unknown fields are handled across feature sets. Build/profile changes (release LTO + single codegen unit) may also affect compile times and binary characteristics but not runtime behavior correctness.
> 
> **Overview**
> **Improves runtime and build-time performance for the SDK client.**
> 
> When `tracing` is *disabled*, the main HTTP `request` path now deserializes responses directly into the target type instead of first parsing into `serde_json::Value` (avoiding a second deserialization pass). When `tracing` is *enabled*, the warning/error logging path in `deserialize_with_warnings` is updated to avoid deep `Value` cloning by storing a single `raw_json` string and re-parsing only when needed.
> 
> Adds a `release` profile in `Cargo.toml` to match `bench` (`lto = "thin"`, `codegen-units = 1`) for more aggressive release optimizations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b9d385f42b08dc32f0fd7b425a73a84b06dc20c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->