### PR TITLE
fix(clob): use correct orderID key in cancel_order request body

### DIFF
--- a/src/clob/client.rs
+++ b/src/clob/client.rs
@@ -1563,7 +1563,7 @@ impl<K: Kind> Client<Authenticated<K>> {
         let request = self
             .client()
             .request(Method::DELETE, format!("{}order", self.host()))
-            .json(&json!({ "orderId": order_id }))
+            .json(&json!({ "orderID": order_id }))
             .build()?;
         let headers = self.create_headers(&request).await?;
 

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -1826,7 +1826,7 @@ mod authenticated {
                 .header(POLY_ADDRESS, client.address().to_string().to_lowercase())
                 .header(POLY_API_KEY, API_KEY)
                 .header(POLY_PASSPHRASE, PASSPHRASE)
-                .json_body(json!({ "orderId": "1" }));
+                .json_body(json!({ "orderID": "1" }));
             then.status(StatusCode::OK).json_body(json!({
                     "canceled": [],
                     "notCanceled": {
@@ -1862,7 +1862,7 @@ mod authenticated {
                 .header(POLY_ADDRESS, client.address().to_string().to_lowercase())
                 .header(POLY_API_KEY, API_KEY)
                 .header(POLY_PASSPHRASE, PASSPHRASE)
-                .json_body(json!({ "orderId": "1" }));
+                .json_body(json!({ "orderID": "1" }));
             then.status(StatusCode::OK).json_body(json!({
                     "canceled": [],
                     "not_canceled": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small request-body key change limited to the `cancel_order` endpoint plus aligned unit tests.
> 
> **Overview**
> Fixes `Client::cancel_order` to send the correct JSON key (`orderID` instead of `orderId`) when issuing the `DELETE /order` request.
> 
> Updates the corresponding `httpmock` expectations in `tests/clob.rs` to match the new request body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616288e7ea1dce2cb6517733d42a8078de7371a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->