### PR TITLE
fix(types): change BuilderTradeResponse.builder from Address to ApiKey

### DIFF
--- a/src/clob/types/response.rs
+++ b/src/clob/types/response.rs
@@ -653,8 +653,8 @@ pub struct BuilderTradeResponse {
     pub trade_type: String,
     /// Hash of the taker order.
     pub taker_order_hash: B256,
-    /// Address of the builder.
-    pub builder: Address,
+    /// Builder API key ID.
+    pub builder: ApiKey,
     /// The market condition ID.
     pub market: B256,
     pub asset_id: U256,

--- a/tests/clob.rs
+++ b/tests/clob.rs
@@ -3157,7 +3157,7 @@ mod builder_authenticated {
                         "id": "1",
                         "tradeType": "limit",
                         "takerOrderHash": "0x0000000000000000000000000000000000000000000000000074616b65726f72",
-                        "builder": "0x00000000000000000000000000006275696c6431",
+                        "builder": "019b618b-4a91-7dd9-a4c9-aadfbcbd5b95",
                         "market": "0x000000000000000000000000000000000000000000000000000000006d61726b",
                         "assetId": token_1(),
                         "side": "buy",
@@ -3199,7 +3199,7 @@ mod builder_authenticated {
             .taker_order_hash(b256!(
                 "0000000000000000000000000000000000000000000000000074616b65726f72"
             ))
-            .builder(address!("00000000000000000000000000006275696c6431"))
+            .builder(Uuid::parse_str("019b618b-4a91-7dd9-a4c9-aadfbcbd5b95").unwrap())
             .market(b256!(
                 "000000000000000000000000000000000000000000000000000000006d61726b"
             ))


### PR DESCRIPTION
## Summary

- Change `BuilderTradeResponse.builder` type from `Address` to `ApiKey` (UUID)
- The `/builder/trades` API returns a UUID for the `builder` field (e.g. `019b618b-4a91-7dd9-a4c9-aadfbcbd5b95`), not an Ethereum address
- `ApiKey` is already used in the same struct for the `owner` field, so this aligns with existing patterns
- Updated test to use a realistic UUID payload

## Note

This is a focused fix for #294 only. PR #297 addresses the same issue but bundles additional scope (#293) and has stalled with unresolved review feedback.

**Breaking change**: `builder` field type changes from `Address` to `ApiKey` (`Uuid`). The previous type caused deserialization failures against the real API, so no working code should be affected.

Closes #294

## Test plan

- [ ] `cargo test --test clob builder_trades` passes with UUID in mock payload
- [ ] Verify deserialization against real `/builder/trades` endpoint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking type change: `BuilderTradeResponse.builder` is now an `ApiKey` (`Uuid`) instead of an Ethereum `Address`, which could impact downstream consumers compiling against this SDK. Scope is small and aligns deserialization with the actual `/builder/trades` payload, reducing runtime failures.
> 
> **Overview**
> Fixes `/builder/trades` deserialization by changing `BuilderTradeResponse.builder` from `Address` to `ApiKey` (`Uuid`), matching the API’s UUID value for the `builder` field.
> 
> Updates the `builder_trades` test fixture and expected `BuilderTradeResponse` construction to use a realistic UUID string instead of an address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c78ae04ba348851a117569460379867ce6ae3755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->