### PR TITLE
feat(gamma): add active filter to MarketsRequest

### DIFF
--- a/src/gamma/types/request.rs
+++ b/src/gamma/types/request.rs
@@ -202,6 +202,7 @@ pub struct MarketsRequest {
     #[builder(default)]
     pub question_ids: Vec<B256>,
     pub include_tag: Option<bool>,
+    pub active: Option<bool>,
     pub closed: Option<bool>,
 }
 

--- a/tests/gamma.rs
+++ b/tests/gamma.rs
@@ -1279,6 +1279,7 @@ mod query_string {
                 b256!("0x0000000000000000000000000000000000000000000000000000000000000002"),
             ])
             .include_tag(true)
+            .active(true)
             .closed(false)
             .build();
 
@@ -1323,6 +1324,7 @@ mod query_string {
             "question_ids=0x0000000000000000000000000000000000000000000000000000000000000002"
         ));
         assert!(qs.contains("include_tag=true"));
+        assert!(qs.contains("active=true"));
         assert!(qs.contains("closed=false"));
     }
 
@@ -1346,6 +1348,27 @@ mod query_string {
         assert!(!qs.contains("market_maker_address="));
         assert!(!qs.contains("sports_market_types="));
         assert!(!qs.contains("question_ids="));
+    }
+
+    #[test]
+    fn markets_request_active_true() {
+        let request = MarketsRequest::builder().active(true).build();
+        let qs = request.query_params(None);
+        assert!(qs.contains("active=true"));
+    }
+
+    #[test]
+    fn markets_request_active_false() {
+        let request = MarketsRequest::builder().active(false).build();
+        let qs = request.query_params(None);
+        assert!(qs.contains("active=false"));
+    }
+
+    #[test]
+    fn markets_request_active_omitted_when_unset() {
+        let request = MarketsRequest::default();
+        let qs = request.query_params(None);
+        assert!(!qs.contains("active"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `active: Option<bool>` to `MarketsRequest`
- Matches the existing pattern used by `EventsRequest` (same field, same position relative to `closed`)
- The Gamma backend already supports `?active=` on the markets endpoint; this exposes it natively so consumers don't need client-side filtering

## Changes

- `src/gamma/types/request.rs`: one field added to `MarketsRequest`
- `tests/gamma.rs`: `active(true)` added to `markets_request_all_params`, plus three focused tests (`active=true`, `active=false`, omitted when unset)

Builder method is auto-generated by `bon::Builder`. Serialization handled by existing `#[skip_serializing_none]`. No behavior change for callers that don't set `active`.

Closes #267

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional boolean query parameter to `MarketsRequest` and extends serialization tests; no behavior change unless callers set `active`.
> 
> **Overview**
> Adds an `active: Option<bool>` filter to `MarketsRequest`, allowing callers to send `?active=true|false` when listing markets.
> 
> Updates query-string unit tests to cover `active` serialization (true/false) and verify it is omitted when unset, and includes `active` in the all-params markets request test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6afff53399440b2db830f53b516f49265d64b908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->