### PR TITLE
test(gamma): add coverage for uma_resolution_status values

### DIFF
--- a/tests/gamma.rs
+++ b/tests/gamma.rs
@@ -1349,6 +1349,40 @@ mod query_string {
     }
 
     #[test]
+    fn markets_request_uma_resolution_status_proposed() {
+        let request = MarketsRequest::builder()
+            .uma_resolution_status("proposed".to_owned())
+            .build();
+        let qs = request.query_params(None);
+        assert!(qs.contains("uma_resolution_status=proposed"));
+    }
+
+    #[test]
+    fn markets_request_uma_resolution_status_disputed() {
+        let request = MarketsRequest::builder()
+            .uma_resolution_status("disputed".to_owned())
+            .build();
+        let qs = request.query_params(None);
+        assert!(qs.contains("uma_resolution_status=disputed"));
+    }
+
+    #[test]
+    fn markets_request_uma_resolution_status_resolved() {
+        let request = MarketsRequest::builder()
+            .uma_resolution_status("resolved".to_owned())
+            .build();
+        let qs = request.query_params(None);
+        assert!(qs.contains("uma_resolution_status=resolved"));
+    }
+
+    #[test]
+    fn markets_request_uma_resolution_status_omitted_when_unset() {
+        let request = MarketsRequest::default();
+        let qs = request.query_params(None);
+        assert!(!qs.contains("uma_resolution_status"));
+    }
+
+    #[test]
     fn market_by_id_request_with_include_tag() {
         let request = MarketByIdRequest::builder()
             .id("42")


### PR DESCRIPTION
## Summary

Add test coverage for the three `uma_resolution_status` values accepted by the Gamma API:
- `proposed` — resolution has been proposed via UMA oracle
- `disputed` — proposed resolution has been disputed
- `resolved` — resolution is finalized

Also adds a test confirming the field is omitted from the query string when unset.

## Verification

Values were confirmed against the live Gamma API — each returns real market data when used as a `?uma_resolution_status=` filter. The `umaResolutionStatuses` field in API responses independently confirms the same three values (e.g. `["proposed", "resolved"]`, `["proposed", "disputed"]`).

## Changes

- `tests/gamma.rs`: 4 new tests, no production code changes

The existing `markets_request_all_params` test already covers `"resolved"`. These tests cover the remaining values individually and verify omission behavior.

Closes #252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only unit tests validating query string serialization for `uma_resolution_status`, with no production code changes.
> 
> **Overview**
> Adds targeted query-string unit tests for `MarketsRequest` to ensure `uma_resolution_status` is serialized correctly for the supported values (`proposed`, `disputed`, `resolved`) and omitted entirely when not set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f16632677e4bcf245d9ef0dee5096b0ed1a6706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->