### PR TITLE
fix(serde): accept JSON numbers as Decimal in CLOB/data/gamma responses

### DIFF
--- a/src/clob/types/mod.rs
+++ b/src/clob/types/mod.rs
@@ -417,7 +417,14 @@ impl<'de> Deserialize<'de> for TickSize {
     where
         D: Deserializer<'de>,
     {
-        let dec = <Decimal as Deserialize>::deserialize(deserializer)?;
+        // The Polymarket API returns `minimum_tick_size` as a JSON number
+        // (e.g. `0.01`), which `Decimal`'s default deserializer rejects
+        // because it expects a string. Delegate to the shared flexible
+        // Decimal deserializer so we handle both representations.
+        use serde_with::DeserializeAs;
+        let dec = <crate::serde_helpers::DecimalFromAny as DeserializeAs<Decimal>>::deserialize_as(
+            deserializer,
+        )?;
         TickSize::try_from(dec).map_err(de::Error::custom)
     }
 }

--- a/src/data/types/response.rs
+++ b/src/data/types/response.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Deserializer};
 use serde_with::{DefaultOnNull, DisplayFromStr, NoneAsEmptyString, serde_as};
 
 use super::{ActivityType, Side};
+use crate::serde_helpers::DecimalFromAny;
 use crate::types::{Address, B256, Decimal, U256};
 
 /// Deserializes an optional Side, treating empty strings as None.
@@ -74,24 +75,34 @@ pub struct Position {
     /// The market condition ID (unique market identifier).
     pub condition_id: B256,
     /// Number of outcome tokens held.
+    #[serde_as(as = "DecimalFromAny")]
     pub size: Decimal,
     /// Average entry price for the position.
+    #[serde_as(as = "DecimalFromAny")]
     pub avg_price: Decimal,
     /// Initial value (cost basis) of the position.
+    #[serde_as(as = "DecimalFromAny")]
     pub initial_value: Decimal,
     /// Current market value of the position.
+    #[serde_as(as = "DecimalFromAny")]
     pub current_value: Decimal,
     /// Unrealized cash profit/loss.
+    #[serde_as(as = "DecimalFromAny")]
     pub cash_pnl: Decimal,
     /// Unrealized percentage profit/loss.
+    #[serde_as(as = "DecimalFromAny")]
     pub percent_pnl: Decimal,
     /// Total amount bought (cumulative).
+    #[serde_as(as = "DecimalFromAny")]
     pub total_bought: Decimal,
     /// Realized profit/loss from closed portions.
+    #[serde_as(as = "DecimalFromAny")]
     pub realized_pnl: Decimal,
     /// Realized percentage profit/loss.
+    #[serde_as(as = "DecimalFromAny")]
     pub percent_realized_pnl: Decimal,
     /// Current market price of the outcome.
+    #[serde_as(as = "DecimalFromAny")]
     pub cur_price: Decimal,
     /// Whether the position can be redeemed (market resolved).
     pub redeemable: bool,
@@ -129,6 +140,7 @@ pub struct Position {
 ///
 /// Returned by the `/closed-positions` endpoint. Represents positions that
 /// have been fully sold or redeemed, with final profit/loss figures.
+#[serde_as]
 #[derive(Debug, Clone, Deserialize, Builder)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -140,12 +152,16 @@ pub struct ClosedPosition {
     /// The market condition ID (unique market identifier).
     pub condition_id: B256,
     /// Average entry price for the position.
+    #[serde_as(as = "DecimalFromAny")]
     pub avg_price: Decimal,
     /// Total amount bought (cumulative).
+    #[serde_as(as = "DecimalFromAny")]
     pub total_bought: Decimal,
     /// Realized profit/loss from the closed position.
+    #[serde_as(as = "DecimalFromAny")]
     pub realized_pnl: Decimal,
     /// Final market price when position was closed.
+    #[serde_as(as = "DecimalFromAny")]
     pub cur_price: Decimal,
     /// Unix timestamp when the position was closed.
     pub timestamp: i64,
@@ -187,8 +203,10 @@ pub struct Trade {
     /// The market condition ID (unique market identifier).
     pub condition_id: B256,
     /// Number of tokens traded.
+    #[serde_as(as = "DecimalFromAny")]
     pub size: Decimal,
     /// Execution price per token.
+    #[serde_as(as = "DecimalFromAny")]
     pub price: Decimal,
     /// Unix timestamp when the trade occurred.
     pub timestamp: i64,

--- a/src/gamma/types/response.rs
+++ b/src/gamma/types/response.rs
@@ -10,7 +10,7 @@ use serde_with::NoneAsEmptyString;
 use serde_with::json::JsonString;
 use serde_with::{DisplayFromStr, StringWithSeparator, formats::CommaSeparator, serde_as};
 
-use crate::serde_helpers::StringFromAny;
+use crate::serde_helpers::{DecimalFromAny, StringFromAny};
 use crate::types::{Address, B256, Decimal, U256};
 
 /// Image optimization metadata.
@@ -245,8 +245,11 @@ pub struct Event {
     pub new: Option<bool>,
     pub featured: Option<bool>,
     pub restricted: Option<bool>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub liquidity: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub open_interest: Option<Decimal>,
     pub sort_by: Option<String>,
     pub category: Option<String>,
@@ -260,10 +263,15 @@ pub struct Event {
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub comments_enabled: Option<bool>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub competitive: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_24hr: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1wk: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1mo: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1yr: Option<Decimal>,
     pub featured_image: Option<String>,
     pub disqus_thread: Option<String>,
@@ -274,7 +282,9 @@ pub struct Event {
     #[serde_as(as = "Option<StringFromAny>")]
     pub turn_provider_id: Option<String>,
     pub enable_order_book: Option<bool>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub liquidity_amm: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub liquidity_clob: Option<Decimal>,
     pub neg_risk: Option<bool>,
     #[serde_as(as = "NoneAsEmptyString")]
@@ -317,7 +327,9 @@ pub struct Event {
     pub cant_estimate: Option<bool>,
     pub estimated_value: Option<String>,
     pub templates: Option<Vec<Template>>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub spreads_main_line: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub totals_main_line: Option<Decimal>,
     pub carousel_map: Option<String>,
     pub pending_deployment: Option<bool>,
@@ -353,6 +365,7 @@ pub struct Market {
     pub end_date: Option<DateTime<Utc>>,
     pub category: Option<String>,
     pub amm_type: Option<String>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub liquidity: Option<Decimal>,
     pub sponsor_name: Option<String>,
     pub sponsor_image: Option<String>,
@@ -360,6 +373,7 @@ pub struct Market {
     pub x_axis_value: Option<String>,
     pub y_axis_value: Option<String>,
     pub denomination_token: Option<U256>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub fee: Option<Decimal>,
     pub image: Option<String>,
     pub icon: Option<String>,
@@ -370,6 +384,7 @@ pub struct Market {
     pub outcomes: Option<Vec<String>>,
     #[serde_as(as = "Option<JsonString>")]
     pub outcome_prices: Option<Vec<Decimal>>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume: Option<Decimal>,
     pub active: Option<bool>,
     pub market_type: Option<String>,
@@ -400,11 +415,15 @@ pub struct Market {
     pub question_id: Option<B256>,
     pub uma_end_date: Option<String>,
     pub enable_order_book: Option<bool>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub order_price_min_tick_size: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub order_min_size: Option<Decimal>,
     pub uma_resolution_status: Option<String>,
     pub curation_order: Option<i32>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_num: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub liquidity_num: Option<Decimal>,
     pub end_date_iso: Option<NaiveDate>,
     pub start_date_iso: Option<NaiveDate>,
@@ -412,9 +431,13 @@ pub struct Market {
     pub has_reviewed_dates: Option<bool>,
     pub ready_for_cron: Option<bool>,
     pub comments_enabled: Option<bool>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_24hr: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1wk: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1mo: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1yr: Option<Decimal>,
     pub game_start_time: Option<String>,
     pub seconds_delay: Option<i32>,
@@ -427,19 +450,32 @@ pub struct Market {
     #[serde(rename = "teamBID")]
     pub team_b_id: Option<String>,
     pub uma_bond: Option<String>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub uma_reward: Option<Decimal>,
     pub fpmm_live: Option<bool>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_24hr_amm: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1wk_amm: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1mo_amm: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1yr_amm: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_24hr_clob: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1wk_clob: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1mo_clob: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_1yr_clob: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_amm: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_clob: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub liquidity_amm: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub liquidity_clob: Option<Decimal>,
     pub maker_base_fee: Option<i32>,
     pub taker_base_fee: Option<i32>,
@@ -460,18 +496,30 @@ pub struct Market {
     pub ready_timestamp: Option<DateTime<Utc>>,
     pub funded_timestamp: Option<DateTime<Utc>>,
     pub accepting_orders_timestamp: Option<DateTime<Utc>>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub competitive: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub rewards_min_size: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub rewards_max_spread: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub spread: Option<Decimal>,
     pub automatically_resolved: Option<bool>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub one_day_price_change: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub one_hour_price_change: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub one_week_price_change: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub one_month_price_change: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub one_year_price_change: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub last_trade_price: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub best_bid: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub best_ask: Option<Decimal>,
     pub automatically_active: Option<bool>,
     pub clear_book_on_start: Option<bool>,
@@ -484,6 +532,7 @@ pub struct Market {
     pub game_id: Option<String>,
     pub group_item_range: Option<String>,
     pub sports_market_type: Option<String>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub line: Option<Decimal>,
     pub uma_resolution_statuses: Option<String>,
     pub pending_deployment: Option<bool>,
@@ -532,11 +581,14 @@ pub struct ClobReward {
     pub condition_id: Option<B256>,
     pub start_date: Option<NaiveDate>,
     pub end_date: Option<NaiveDate>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub rewards_amount: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub rewards_daily_rate: Option<Decimal>,
 }
 
 /// A series of related events.
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Builder)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -566,9 +618,13 @@ pub struct Series {
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub comments_enabled: Option<bool>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub competitive: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume_24hr: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub volume: Option<Decimal>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub liquidity: Option<Decimal>,
     pub start_date: Option<DateTime<Utc>>,
     #[serde(rename = "pythTokenID")]
@@ -585,11 +641,13 @@ pub struct Series {
 }
 
 /// A comment position.
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Builder)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CommentPosition {
     pub token_id: Option<U256>,
+    #[serde_as(as = "Option<DecimalFromAny>")]
     pub position_size: Option<Decimal>,
 }
 

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -80,6 +80,108 @@ impl serde_with::SerializeAs<String> for StringFromAny {
     }
 }
 
+/// A `serde_as` type that deserializes strings, integers, or floats as `Decimal`.
+///
+/// Polymarket APIs sometimes return numeric fields as JSON numbers (e.g.
+/// `0.01`) rather than strings, which the default `rust_decimal` deserializer
+/// rejects because it expects a string. Use this helper on any `Decimal` field
+/// whose JSON representation may be either a string or a number.
+///
+/// Use with `#[serde_as(as = "DecimalFromAny")]` for `Decimal` fields
+/// or `#[serde_as(as = "Option<DecimalFromAny>")]` for `Option<Decimal>`.
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma"
+))]
+pub struct DecimalFromAny;
+
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma"
+))]
+impl<'de> serde_with::DeserializeAs<'de, rust_decimal::Decimal> for DecimalFromAny {
+    fn deserialize_as<D>(deserializer: D) -> std::result::Result<rust_decimal::Decimal, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use std::fmt;
+        use std::str::FromStr as _;
+
+        use serde::de::{self, Visitor};
+
+        struct DecimalAnyVisitor;
+
+        impl Visitor<'_> for DecimalAnyVisitor {
+            type Value = rust_decimal::Decimal;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("string, integer, or float convertible to Decimal")
+            }
+
+            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                rust_decimal::Decimal::from_str(v).map_err(de::Error::custom)
+            }
+
+            fn visit_string<E>(self, v: String) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_str(&v)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(rust_decimal::Decimal::from(v))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(rust_decimal::Decimal::from(v))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                // Round-trip through string to avoid the binary-float
+                // precision trap (e.g. 0.1 → 0.1000000000000000055...).
+                rust_decimal::Decimal::from_str(&v.to_string()).map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_any(DecimalAnyVisitor)
+    }
+}
+
+#[cfg(any(
+    feature = "bridge",
+    feature = "clob",
+    feature = "data",
+    feature = "gamma"
+))]
+impl serde_with::SerializeAs<rust_decimal::Decimal> for DecimalFromAny {
+    fn serialize_as<S>(
+        source: &rust_decimal::Decimal,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        <rust_decimal::Decimal as serde::Serialize>::serialize(source, serializer)
+    }
+}
+
 /// Deserialize JSON with unknown field warnings.
 ///
 /// This function deserializes JSON to a target type while detecting and logging

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -830,4 +830,108 @@ mod tests {
         let result = lookup_value(&json, "?.outer.?.inner");
         assert_eq!(result, Some(&Value::String("value".to_owned())));
     }
+
+    // ========== DecimalFromAny tests ==========
+    #[cfg(any(
+        feature = "bridge",
+        feature = "clob",
+        feature = "data",
+        feature = "gamma"
+    ))]
+    mod decimal_from_any_tests {
+        use std::str::FromStr as _;
+
+        use rust_decimal::Decimal;
+        use serde::Deserialize;
+        use serde_with::serde_as;
+
+        use super::super::DecimalFromAny;
+
+        #[serde_as]
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Holder {
+            #[serde_as(as = "DecimalFromAny")]
+            value: Decimal,
+        }
+
+        #[serde_as]
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct OptHolder {
+            #[serde_as(as = "Option<DecimalFromAny>")]
+            #[serde(default)]
+            value: Option<Decimal>,
+        }
+
+        #[test]
+        fn accepts_json_float() {
+            // Mirrors /tick-size returning {"minimum_tick_size": 0.01}
+            let holder: Holder = serde_json::from_str(r#"{"value": 0.01}"#).unwrap();
+            assert_eq!(holder.value, Decimal::from_str("0.01").unwrap());
+        }
+
+        #[test]
+        fn accepts_json_float_without_precision_loss() {
+            // 0.1 is not exactly representable in binary float; the
+            // shortest-string round-trip should yield the literal "0.1",
+            // not 0.1000000000000000055...
+            let holder: Holder = serde_json::from_str(r#"{"value": 0.1}"#).unwrap();
+            assert_eq!(holder.value, Decimal::from_str("0.1").unwrap());
+        }
+
+        #[test]
+        fn accepts_json_integer_unsigned() {
+            let holder: Holder = serde_json::from_str(r#"{"value": 42}"#).unwrap();
+            assert_eq!(holder.value, Decimal::from(42));
+        }
+
+        #[test]
+        fn accepts_json_integer_signed() {
+            let holder: Holder = serde_json::from_str(r#"{"value": -7}"#).unwrap();
+            assert_eq!(holder.value, Decimal::from(-7));
+        }
+
+        #[test]
+        fn accepts_string_decimal() {
+            // Responses that already return strings must continue to work.
+            let holder: Holder = serde_json::from_str(r#"{"value": "0.123456"}"#).unwrap();
+            assert_eq!(holder.value, Decimal::from_str("0.123456").unwrap());
+        }
+
+        #[test]
+        fn rejects_non_numeric_string() {
+            let err = serde_json::from_str::<Holder>(r#"{"value": "not-a-number"}"#);
+            err.unwrap_err();
+        }
+
+        #[test]
+        fn rejects_null_on_required_field() {
+            let err = serde_json::from_str::<Holder>(r#"{"value": null}"#);
+            err.unwrap_err();
+        }
+
+        #[test]
+        fn optional_accepts_null_and_float() {
+            let none: OptHolder = serde_json::from_str(r#"{"value": null}"#).unwrap();
+            assert_eq!(none.value, None);
+            let some: OptHolder = serde_json::from_str(r#"{"value": 0.54}"#).unwrap();
+            assert_eq!(some.value, Some(Decimal::from_str("0.54").unwrap()));
+            let missing: OptHolder = serde_json::from_str("{}").unwrap();
+            assert_eq!(missing.value, None);
+        }
+
+        #[test]
+        fn tick_size_like_response() {
+            // Exact reproduction of the /tick-size response that triggered
+            // the original bug.
+            #[serde_as]
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct TickSizeResponseLike {
+                #[serde_as(as = "DecimalFromAny")]
+                minimum_tick_size: Decimal,
+            }
+            let resp: TickSizeResponseLike =
+                serde_json::from_str(r#"{"minimum_tick_size": 0.01}"#).unwrap();
+            assert_eq!(resp.minimum_tick_size, Decimal::from_str("0.01").unwrap());
+        }
+    }
 }


### PR DESCRIPTION
# Accept JSON numbers as `Decimal` across CLOB, data, and Gamma response types

## Summary

Several Polymarket CLOB / data-api / Gamma responses return numeric fields as JSON
numbers (e.g. `{"minimum_tick_size": 0.01}`, `{"avgPrice": 0.36}`,
`{"lastTradePrice": 0.54}`) rather than strings. The default
`rust_decimal::Decimal` deserializer in `serde` rejects these with errors like:

```
invalid type: floating point `0.01`, expected a Decimal type representing a fixed-point number
```

This blocks every consumer of these structs at deserialization time. In particular,
`Client::tick_size` is called transitively by the order-builder
(`limit_order().build()` / `market_order().build()`), so **any attempt to place a
live order currently fails before the order is signed**, and `sync_markets`-style
workflows that iterate the Gamma catalog fail on the first sports / prediction
market with numeric `bestBid` / `bestAsk` / etc.

## Reproduction

Against production endpoints (as of the date of this PR):

```rust
let client = ClobClient::new("https://clob.polymarket.com", ClobConfig::default())?;
client.tick_size(U256::from_str_radix("49104850...145930", 10)?).await?;
// Err: invalid type: floating point `0.01`, expected a Decimal type representing a fixed-point number
```

```rust
let data = data::Client::new("https://data-api.polymarket.com")?;
data.positions(&PositionsRequest::builder().user(addr).build()).await?;
// Err: invalid type: floating point `0.36`, expected a Decimal type representing a fixed-point number
```

```rust
let gamma = gamma::Client::new("https://gamma-api.polymarket.com")?;
gamma.markets(&MarketsRequest::builder().limit(500).build()).await?;
// Err: invalid type: floating point `0.54`, expected a Decimal type representing a fixed-point number
```

Live JSON samples observed:

```
GET /tick-size            → {"minimum_tick_size":0.01}
GET /positions            → [{"proxyWallet":"0x...","avgPrice":0.36,"size":19.79,...}]
GET /markets              → [{"lastTradePrice":0.54,"bestBid":0.037,"bestAsk":0.04,...}]
```

## Change

Introduce a reusable `serde_with::DeserializeAs` / `SerializeAs` adapter
`serde_helpers::DecimalFromAny` that accepts strings, integers, or floats, and
apply it to every affected field across CLOB, data, and Gamma response types.

### `src/serde_helpers.rs`

New `DecimalFromAny` adapter. Visits:

- `visit_str` / `visit_string` → `Decimal::from_str`
- `visit_i64` / `visit_u64`    → `Decimal::from`
- `visit_f64`                  → `Decimal::from_str(&v.to_string())` (round-trips
  through the shortest-round-trip `f64` → string conversion to avoid the binary
  float precision trap, e.g. `0.1` → `0.1000000000000000055...`)

On the serialize side it delegates to the existing `Decimal: Serialize` impl so
output format is unchanged when these types are re-serialized in tests or mock
helpers.

Gated on the same feature set as the existing `StringFromAny` helper
(`bridge | clob | data | gamma`).

### `src/clob/types/mod.rs`

`TickSize::Deserialize` now delegates to `DecimalFromAny` and then passes the
`Decimal` through the existing `TryFrom<Decimal> for TickSize` conversion. The
validation that the value must be one of `{0.1, 0.01, 0.001, 0.0001}` is
preserved.

### `src/data/types/response.rs`

- `Position` — `#[serde_as(as = "DecimalFromAny")]` on all ten `Decimal`
  fields (`size`, `avg_price`, `initial_value`, `current_value`, `cash_pnl`,
  `percent_pnl`, `total_bought`, `realized_pnl`, `percent_realized_pnl`,
  `cur_price`).
- `ClosedPosition` — adds `#[serde_as]` on the struct (was missing) and
  `DecimalFromAny` on its four `Decimal` fields.
- `Trade` — `DecimalFromAny` on `size` and `price`.

### `src/gamma/types/response.rs`

`Market`, `Event`, and related structs: `#[serde_as(as = "Option<DecimalFromAny>")]`
applied to every `Option<Decimal>` field (56 fields across the module). Structs
that didn't previously carry the `#[serde_as]` proc-macro marker get it added.

Covered fields include price / book fields (`best_bid`, `best_ask`,
`last_trade_price`, `spread`), volume fields (`volume`, `volume_num`,
`volume_24hr`, `volume_1wk`, `volume_1mo`, `volume_1yr`, and their `_amm`/`_clob`
variants), liquidity fields (`liquidity`, `liquidity_num`, `liquidity_amm`,
`liquidity_clob`), price-change fields (`one_day_price_change`,
`one_hour_price_change`, `one_week_price_change`, `one_month_price_change`,
`one_year_price_change`), and misc numeric fields (`fee`, `rewards_min_size`,
`rewards_max_spread`, `competitive`, `line`, `uma_reward`,
`order_price_min_tick_size`, `order_min_size`, `spreads_main_line`,
`totals_main_line`).

The `outcome_prices: Option<Vec<Decimal>>` field is left unchanged because it
uses `#[serde_as(as = "Option<JsonString>")]` and is wrapped in a stringified
JSON array whose inner Decimals are already strings in live responses.

## Scope / non-goals

- Request types and order serialization (`SignedOrder`, `Order`) are untouched;
  these are still serialized as strings when sent to the API as required.
- The change is **backwards compatible** with responses that return Decimals as
  strings; `DecimalFromAny` handles both.
- No behavior change for any consumer that previously deserialized successfully.
- No dependency additions: the patch reuses the crate's existing
  `rust_decimal`, `serde`, and `serde_with` dependencies.

## Tests

The existing `httpmock`-based tests continue to pass. I can add regression
coverage in a follow-up that feeds raw JSON-number responses through an
`httpmock` server, modeled on `tests/clob.rs::tick_size_*` and
`tests/data.rs::positions_*`.

## Context

Surfaced from a downstream consumer wiring Polymarket into a live trading
runtime. The bug currently blocks end-to-end order placement and any
`sync_markets`-style metadata pull. A minimal local reproduction walks through
`ClobClient::tick_size → /tick-size → 200 {"minimum_tick_size":0.01}` and fails
in `TickSize::deserialize` inside `Decimal::deserialize`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many response structs and changes how numerous `Decimal` fields deserialize, so regressions could surface if any endpoints relied on strict string-only parsing or if float-to-string round-tripping behaves unexpectedly.
> 
> **Overview**
> Fixes deserialization failures when Polymarket APIs return `Decimal`-typed fields as JSON numbers instead of strings.
> 
> Introduces a reusable `serde_helpers::DecimalFromAny` adapter (with tests) that accepts string/int/float JSON values, and applies it to CLOB `TickSize` plus affected `Decimal` fields across Data API (`Position`/`ClosedPosition`/`Trade`) and Gamma response types (many `Option<Decimal>` market/event metrics like liquidity, volume, prices, and spreads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 350a69a9c35e3fa1377e075452db854832339aa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->