### PR TITLE
fix(gamma): add missing teams field to Event

### DIFF
--- a/src/gamma/types/response.rs
+++ b/src/gamma/types/response.rs
@@ -334,6 +334,7 @@ pub struct Event {
     pub cumulative_markets: Option<bool>,
     pub away_team_name: Option<String>,
     pub home_team_name: Option<String>,
+    pub teams: Option<Vec<Team>>,
 }
 
 /// A prediction market.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk additive change: introduces an optional `teams` array on `Event` deserialization/serialization, with no behavioral logic changes.
> 
> **Overview**
> Adds a missing `teams: Option<Vec<Team>>` field to the `Event` response model in `src/gamma/types/response.rs`, allowing event payloads to include full team objects (not just `home_team_name`/`away_team_name`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640baaf2bec6989b976f83c2eec510b343bb1fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->