### PR TITLE
docs(ws): correct BookUpdate bid/ask ordering in doc comments

### DIFF
--- a/src/clob/ws/types/response.rs
+++ b/src/clob/ws/types/response.rs
@@ -76,10 +76,10 @@ pub struct BookUpdate {
     /// Unix timestamp in milliseconds
     #[serde_as(as = "DisplayFromStr")]
     pub timestamp: i64,
-    /// Current bid levels (price descending)
+    /// Current bid levels (price ascending)
     #[serde(default)]
     pub bids: Vec<OrderBookLevel>,
-    /// Current ask levels (price ascending)
+    /// Current ask levels (price descending)
     #[serde(default)]
     pub asks: Vec<OrderBookLevel>,
     /// Hash for orderbook validation


### PR DESCRIPTION
## Summary

The `BookUpdate` struct in `src/clob/ws/types/response.rs` documents `bids` as price-descending and `asks` as price-ascending, but the server delivers them in the opposite order.

Closes #330.

## Evidence

The reporter's reproduction (included in the issue) printed:
```
bids.first(): 0.01 | bids.last(): 0.13    → ascending
asks.first(): 0.99 | asks.last(): 0.14    → descending
bids ascending: true | asks descending: true
```

The struct does no sorting itself — `Vec<OrderBookLevel>` is populated straight from the deserialized WS payload. The mismatch is in the doc comments, not the data.

## Change

```diff
-    /// Current bid levels (price descending)
+    /// Current bid levels (price ascending)
     #[serde(default)]
     pub bids: Vec<OrderBookLevel>,
-    /// Current ask levels (price ascending)
+    /// Current ask levels (price descending)
     #[serde(default)]
     pub asks: Vec<OrderBookLevel>,
```

## Why doc-fix, not code-fix

Re-sorting in the client would silently change an existing wire-order contract and break any downstream consumer that already indexes into these vectors. The server is the source of truth; documenting its actual order is the conservative fix. Users who want the best bid / best ask can use `bids.last()` / `asks.last()` under the current ordering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only Rust doc comments change; no serialization, parsing, or runtime behavior is modified.
> 
> **Overview**
> **Documentation-only fix for WS orderbook updates.** Updates the `BookUpdate` field comments in `response.rs` to match the wire format: `bids` are *price ascending* and `asks` are *price descending* (previously documented the opposite).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7179711ae92b4aaada4122c6be47846b21b1b2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->