### PR TITLE
fix(rtds): serialize crypto_prices filters as comma-separated string (closes #270)

### DIFF
--- a/src/rtds/types/request.rs
+++ b/src/rtds/types/request.rs
@@ -71,9 +71,18 @@ impl Subscription {
     /// Create a subscription for Binance crypto prices.
     #[must_use]
     pub fn crypto_prices(symbols: Option<Vec<String>>) -> Self {
-        // Server expects filters as a JSON array, e.g. ["btcusdt","ethusdt"]
-        let filters =
-            symbols.map(|s| serde_json::to_string(&s).unwrap_or_else(|_| "[]".to_owned()));
+        // Server expects filters as a comma-separated plain string,
+        // e.g. `"btcusdt,ethusdt"`. The published RTDS schema at
+        // https://docs.polymarket.com/market-data/websocket/rtds is
+        // explicit about this: `"filters": "solusdt,btcusdt,ethusdt"`.
+        // The prior implementation serialized the Vec via
+        // `serde_json::to_string` which produced `["btcusdt","ethusdt"]`
+        // on the wire. The server silently rejects that shape with
+        // `{"message":"Invalid request body"}` while leaving the
+        // WebSocket connection open, so callers see a live stream
+        // that never forwards any ticks — no visible error anywhere.
+        // See #270 for the original bug report.
+        let filters = symbols.map(|s| s.join(","));
         Self {
             topic: "crypto_prices".to_owned(),
             msg_type: "update".to_owned(),
@@ -183,8 +192,14 @@ mod tests {
         let json = serde_json::to_string(&request).unwrap();
         assert!(json.contains("\"action\":\"subscribe\""));
         assert!(json.contains("\"topic\":\"crypto_prices\""));
-        // Filters should be a JSON array, not a comma-separated string
-        assert!(json.contains("\"filters\":[\"btcusdt\",\"ethusdt\"]"));
+        // Filters must be a comma-separated plain string per the RTDS
+        // schema (https://docs.polymarket.com/market-data/websocket/rtds):
+        //   "filters": "btcusdt,ethusdt"
+        // Sending a JSON array was the bug reported in #270.
+        assert!(
+            json.contains("\"filters\":\"btcusdt,ethusdt\""),
+            "Binance crypto_prices filters must be a comma-separated string, got: {json}"
+        );
     }
 
     #[test]
@@ -250,10 +265,11 @@ mod tests {
             json.contains(r#""filters":"{\"symbol\":\"btc/usd\"}""#),
             "Chainlink filters should be escaped string, got: {json}"
         );
-        // Binance should have raw JSON array filters
+        // Binance filters serialize as a comma-separated plain string
+        // per the RTDS schema (#270).
         assert!(
-            json.contains("\"filters\":[\"btcusdt\",\"ethusdt\"]"),
-            "Binance filters should be raw JSON array, got: {json}"
+            json.contains("\"filters\":\"btcusdt,ethusdt\""),
+            "Binance crypto_prices filters must be a comma-separated string, got: {json}"
         );
     }
 


### PR DESCRIPTION
## Summary

`Subscription::crypto_prices` serializes its `filters` field as a JSON array (`["btcusdt","ethusdt"]`), but the Polymarket RTDS server expects a comma-separated plain string (`"btcusdt,ethusdt"`) per the [published schema](https://docs.polymarket.com/market-data/websocket/rtds). The server silently rejects the JSON-array body with `{\"message\":\"Invalid request body\"}` while leaving the WebSocket connection open — consumers see a live stream that never forwards any ticks, with no visible error anywhere in the SDK path.

This matches the bug described in #270. The reporter closed that issue without a fix merged, so v0.4.4 still ships the broken serialization. This PR adopts the reporter's one-liner recommendation.

## Repro (observed in production)

Downstream consumer of `polymarket-client-sdk = \"0.4.4\"`, subscribed via:

\`\`\`rust
client.subscribe_crypto_prices(Some(vec![\"btcusdt\".into(), \"ethusdt\".into(), \"solusdt\".into(), \"xrpusdt\".into(), \"dogeusdt\".into()]))
\`\`\`

Outcome: `binance_ticks_forwarded` counter stayed at **0** across ≥6 hours while `chainlink_ticks_forwarded` (on the same `Client`) accumulated at a healthy ~4.95 tps. No `RTDS stream error` warnings, no `stream ENDED` log line — the stream simply never yielded any items.

Passing `None` instead (no server-side filter) resumes tick flow immediately, confirming the filter shape is the root cause.

## Fix

Replace the JSON array encoding with a `join(\",\")`:

\`\`\`rust
-    let filters =
-        symbols.map(|s| serde_json::to_string(&s).unwrap_or_else(|_| \"[]\".to_owned()));
+    let filters = symbols.map(|s| s.join(\",\"));
\`\`\`

The existing custom `Serialize` impl already handles plain-string filters correctly via the fallback branch (the JSON re-parse fails for a comma-separated string and falls through to `map.serialize_entry(\"filters\", filters)?`, which emits the string value as-is). No changes needed there.

The two unit tests that encoded the old (broken) expected shape are updated to match the documented wire format:
- `serialize_subscription_request` — asserts `\"filters\":\"btcusdt,ethusdt\"`
- `serialize_mixed_subscriptions` — same assertion in the multi-topic case

## Chainlink

`crypto_prices_chainlink` is unaffected. Its filter shape (`\"{\\\"symbol\\\":\\\"btc/usd\\\"}\"`) is correct per #136 and remains serialized as an escaped JSON string by the existing Chainlink branch in the `Serialize` impl.

## Test plan

- [x] \`cargo test --lib --features rtds\` → **36 passed / 0 failed**
- [x] Updated assertions match the RTDS schema example in the official docs
- [x] `crypto_prices_chainlink` serialization unchanged (verified by `serialize_chainlink_subscription` passing)
- [ ] Maintainer to verify against a live RTDS server

Closes #270.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk wire-format fix limited to RTDS Binance `crypto_prices` subscription serialization; main risk is behavior change for any consumers relying on the previous (incorrect) JSON-array encoding.
> 
> **Overview**
> Fixes RTDS Binance `crypto_prices` subscriptions to serialize `filters` as a comma-separated string (e.g. `"btcusdt,ethusdt"`) instead of a JSON array, matching the published RTDS schema and preventing silent server rejection/no-tick streams.
> 
> Updates unit tests to assert the new on-the-wire format (including mixed Chainlink+Binance requests) while keeping Chainlink filter serialization unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 223716d6aeceabeb9cbdf3be8f95019228132cb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->