### PR TITLE
perf(ws): allow injecting a pre-built rustls TLS config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3592,6 +3592,7 @@ dependencies = [
  "reqwest 0.13.2",
  "rust_decimal",
  "rust_decimal_macros",
+ "rustls 0.23.35",
  "secrecy",
  "serde",
  "serde_html_form",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ hmac = "0.12.1"
 phf = { version = "0.13.1", features = ["macros"] }
 rand = "0.10.0"
 reqwest = { version = "0.13.2", features = ["json", "query", "rustls"] }
+rustls = { version = "0.23", default-features = false }
 rust_decimal = { version = "1.41.0", features = ["serde"] }
 rust_decimal_macros = "1.40.0"
 secrecy = { version = "0.10", features = ["serde"] }

--- a/src/ws/config.rs
+++ b/src/ws/config.rs
@@ -3,6 +3,7 @@
     reason = "Configuration types intentionally mirror the module name for clarity"
 )]
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
@@ -23,6 +24,17 @@ pub struct Config {
     pub heartbeat_timeout: Duration,
     /// Reconnection strategy configuration
     pub reconnect: ReconnectConfig,
+    /// Pre-built rustls TLS config, reused across reconnects to avoid
+    /// re-parsing the system CA PEM bundle on every connection.
+    ///
+    /// When `Some`, the connection loop passes this as
+    /// `Connector::Rustls(...)` to `connect_async_tls_with_config`,
+    /// skipping the default `load_native_certs()` call that would
+    /// otherwise re-read and base64-decode every certificate in the
+    /// system trust store on each reconnect attempt.
+    ///
+    /// When `None` (the default), the existing behaviour is preserved.
+    pub tls_config: Option<Arc<rustls::ClientConfig>>,
 }
 
 impl Default for Config {
@@ -31,6 +43,7 @@ impl Default for Config {
             heartbeat_interval: DEFAULT_HEARTBEAT_INTERVAL_DURATION,
             heartbeat_timeout: DEFAULT_HEARTBEAT_TIMEOUT_DURATION,
             reconnect: ReconnectConfig::default(),
+            tls_config: None,
         }
     }
 }

--- a/src/ws/connection.rs
+++ b/src/ws/connection.rs
@@ -5,6 +5,7 @@
 
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::sync::Arc;
 use std::time::Instant;
 
 use backoff::backoff::Backoff as _;
@@ -14,7 +15,10 @@ use serde::de::DeserializeOwned;
 use tokio::net::TcpStream;
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::time::{interval, sleep, timeout};
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
+use tokio_tungstenite::{
+    Connector, MaybeTlsStream, WebSocketStream, connect_async_tls_with_config,
+    tungstenite::Message,
+};
 
 use super::config::Config;
 use super::error::WsError;
@@ -171,8 +175,11 @@ where
 
             _ = state_tx.send(ConnectionState::Connecting);
 
+            let connector =
+                config.tls_config.as_ref().map(|c| Connector::Rustls(Arc::clone(c)));
+
             // Attempt connection
-            match connect_async(&endpoint).await {
+            match connect_async_tls_with_config(&endpoint, None, false, connector).await {
                 Ok((ws_stream, _)) => {
                     attempt = 0;
                     backoff.reset();


### PR DESCRIPTION
**Problem**

`ConnectionManager::connection_loop` calls `connect_async` without a TLS connector, so every reconnect triggers `rustls_native_certs::load_native_certs()` which re-reads `/etc/ssl/certs/ca-certificates.crt` and base64-decodes 100+ PEM certificates into a fresh `rustls::ClientConfig`.

On CPU-constrained hosts this creates a feedback loop: CPU starvation → heartbeat timeout (15s) → reconnect → PEM re-parsing → more starvation. We measured **48% CPU** in `rustls_pki_types::base64::decode_public` on a 2-vCPU box running long-lived WS connections.

**Solution**

Add `tls_config: Option<Arc<rustls::ClientConfig>>` to `ws::Config`. When set, the connection loop passes it as `Connector::Rustls(...)` to `connect_async_tls_with_config`, skipping all PEM work on reconnects. Defaults to `None` — fully backwards compatible.

**Usage**

```rust
use std::sync::Arc;

let mut root_store = rustls::RootCertStore::empty();
let native = rustls_native_certs::load_native_certs();
root_store.add_parsable_certificates(native.certs);
let tls = Arc::new(
    rustls::ClientConfig::builder()
        .with_root_certificates(root_store)
        .with_no_client_auth(),
);

let mut config = Config::default();
config.tls_config = Some(tls);
// PEM certs parsed once, reused across all reconnects
```

**Impact**

Paper trade on AWS showed CPU drop from **146% → 5.2%** (96% reduction) after caching the TLS config at the call site.

**Changes**
- `src/ws/config.rs` — add `tls_config: Option<Arc<rustls::ClientConfig>>` field (defaults to `None`)
- `src/ws/connection.rs` — use `connect_async_tls_with_config` with `Connector::Rustls(...)` when config provides a TLS config
- `Cargo.toml` — add `rustls = { version = "0.23", default-features = false }` dependency