### PR TITLE
docs: add archive notice and link to V2 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!WARNING]
+> This repository has been archived and is no longer maintained.
+>
+> The client is no longer functional and should not be used for new or existing integrations.
+>
+> Please migrate to the V2 client:
+> https://github.com/Polymarket/rs-clob-client-v2
+
 ![Polymarket](assets/logo.png)
 
 # Polymarket Rust Client


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it only updates the README messaging and does not affect any runtime code.
> 
> **Overview**
> Adds a prominent `WARNING` banner at the top of `README.md` stating the repository is archived/unmaintained, the client is no longer functional, and directing users to migrate to the V2 client (`rs-clob-client-v2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416eebbb34e96f3b8d3d8d2f1f5bb5edc39d8c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->